### PR TITLE
Refactor routing rules in generator.go and update types.go

### DIFF
--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -371,10 +371,13 @@ func defaultRouting() *Routing {
 	return &Routing{
 		DomainStrategy: "IPIfNonMatch",
 		Rules: []RoutingRule{
-			{Type: "field", OutboundTag: "block", GeoSite: []string{"category-ads-all"}},
-			{Type: "field", OutboundTag: "direct", GeoIP: []string{"private"}},
-			{Type: "field", OutboundTag: "direct", GeoSite: []string{"cn"}},
-			{Type: "field", OutboundTag: "direct", GeoIP: []string{"cn"}},
+			// Block ads / trackers
+			{Type: "field", OutboundTag: "block", Domain: []string{"geosite:category-ads-all"}},
+			// Direct for private networks
+			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:private"}},
+			// Direct for CN domains / IPs
+			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:cn"}},
+			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:cn"}},
 		},
 	}
 }

--- a/internal/xray/types.go
+++ b/internal/xray/types.go
@@ -308,8 +308,6 @@ type RoutingRule struct {
 	InboundTag  []string `json:"inboundTag,omitempty"`
 	OutboundTag string   `json:"outboundTag"`
 	Domain      []string `json:"domain,omitempty"`
-	GeoSite     []string `json:"geosite,omitempty"`
-	GeoIP       []string `json:"geoip,omitempty"`
 	IP          []string `json:"ip,omitempty"`
 	Network     string   `json:"network,omitempty"`
 	Port        string   `json:"port,omitempty"`


### PR DESCRIPTION
- Updated routing rules to use Domain and IP fields instead of GeoSite and GeoIP for better clarity and consistency.
- Added comments to describe the purpose of each routing rule for improved readability.