### PR TITLE
Reintroduce routing rules for blocked domains in defaultRouting function

### DIFF
--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -522,8 +522,6 @@ func defaultRouting() *Routing {
 	return &Routing{
 		DomainStrategy: "IPOnDemand",
 		Rules: []RoutingRule{
-			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
-			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
 			{
 				Type:        "field",
 				OutboundTag: "direct",
@@ -547,6 +545,8 @@ func defaultRouting() *Routing {
 				},
 			},
 			{Type: "field", OutboundTag: "direct", Protocol: []string{"bittorrent"}},
+			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
+			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
 			{
 				Type:        "field",
 				OutboundTag: "block",


### PR DESCRIPTION
- Moved the rules for blocking Russian domains back into the defaultRouting function.
- Ensures that both domain and IP-based blocking for "geosite:ru-blocked" is consistently applied in routing logic.