### PR TITLE
Implement mobile profile support in subscription API and update docum…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ $EDITOR /etc/xray-subscription/config.json
   "db_path": "/var/lib/xray-subscription/db.sqlite",
   "sync_interval_seconds": 60,
   "base_url": "http://YOUR_SERVER_IP:8080",
-  "admin_token": "choose-a-strong-secret-token"
+  "admin_token": "choose-a-strong-secret-token",
+  "balancer_strategy": "leastPing",
+  "balancer_probe_url": "https://www.gstatic.com/generate_204",
+  "balancer_probe_interval": "30s"
 }
 ```
 
@@ -110,6 +113,8 @@ Create `/etc/xray-subscription/config.json`:
 Notes:
 - Use `:8080` or `0.0.0.0:8080` for `listen_addr` (do not use domain name there).
 - `config_dir` must contain your Xray inbound configs.
+- `balancer_strategy`: `random`, `leastPing`, or `leastLoad` (default: `leastPing`).
+- `balancer_probe_*` is used by `leastPing`/`leastLoad` observatory checks.
 
 ### 4) Manual start test
 
@@ -266,6 +271,8 @@ curl "http://HOST:8080/sub/<token>?profile=mobile"
 | `POST` | `/api/routes/global` | Add one global routing rule |
 | `PUT` | `/api/routes/global` | Replace all global routing rules |
 | `DELETE` | `/api/routes/global` | Clear all global routing rules |
+| `GET` | `/api/config/balancer` | Get effective balancer config |
+| `PUT` | `/api/config/balancer` | Set/reset runtime balancer override |
 | `POST` | `/api/sync` | Trigger manual sync from config.d |
 
 Routing rule constraints for both user/global routes:
@@ -309,6 +316,26 @@ curl -X POST "http://HOST:8080/api/routes/global" \
 
 - `raw_config` is returned as parsed JSON object/array when valid.
 - If stored raw config is malformed JSON, `raw_config` is returned as string (fallback).
+
+Balancer runtime override examples:
+
+```bash
+# Set runtime balancer strategy (takes effect immediately for new generated configs)
+curl -X PUT "http://HOST:8080/api/config/balancer" \
+  -H "X-Admin-Token: TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "strategy": "leastPing",
+    "probe_url": "https://www.gstatic.com/generate_204",
+    "probe_interval": "30s"
+  }'
+
+# Reset runtime override and return to config.json values
+curl -X PUT "http://HOST:8080/api/config/balancer" \
+  -H "X-Admin-Token: TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reset": true}'
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ All admin endpoints require `X-Admin-Token: <your-token>` header.
 - `?inbound_tag=vless-xhttp-in-1`
 - `?format=v2box` or `?format=links` (plain-text proxy links instead of full JSON)
 - `?format=b64` (base64-encoded proxy links)
+- `?profile=mobile` (strip `geosite:` / `geoip:` selectors from routing rules)
+- `?mobile=1` (same as `profile=mobile`)
 
 Examples:
 
@@ -228,6 +230,9 @@ curl "http://HOST:8080/sub/<token>/links.b64"
 
 # Same as links.txt, via format query
 curl "http://HOST:8080/sub/<token>?format=v2box"
+
+# Mobile-friendly JSON profile (no geosite/geoip selectors in routing rules)
+curl "http://HOST:8080/sub/<token>?profile=mobile"
 ```
 
 ### Users

--- a/README.ru.md
+++ b/README.ru.md
@@ -70,6 +70,8 @@ cp config.json.example /etc/xray-subscription/config.json
 - `?protocol=vless` (также `vmess`, `trojan`, `shadowsocks`, `socks`)
 - `?inbound_tag=vless-xhttp-in-1`
 - `?format=v2box` / `?format=links` / `?format=b64`
+- `?profile=mobile` (удаляет из роутинга селекторы `geosite:` / `geoip:`)
+- `?mobile=1` (то же, что `profile=mobile`)
 
 Примеры:
 
@@ -78,6 +80,7 @@ curl "http://HOST:8080/sub/<token>"
 curl "http://HOST:8080/sub/<token>/links.txt"
 curl "http://HOST:8080/sub/<token>/links.b64"
 curl "http://HOST:8080/sub/<token>?format=v2box"
+curl "http://HOST:8080/sub/<token>?profile=mobile"
 ```
 
 ---

--- a/README.ru.md
+++ b/README.ru.md
@@ -44,9 +44,17 @@ cp config.json.example /etc/xray-subscription/config.json
   "db_path": "/var/lib/xray-subscription/db.sqlite",
   "sync_interval_seconds": 60,
   "base_url": "http://YOUR_DOMAIN_OR_IP:8080",
-  "admin_token": "CHANGE_ME"
+  "admin_token": "CHANGE_ME",
+  "balancer_strategy": "leastPing",
+  "balancer_probe_url": "https://www.gstatic.com/generate_204",
+  "balancer_probe_interval": "30s"
 }
 ```
+
+Параметры балансировки:
+
+- `balancer_strategy`: `random`, `leastPing`, `leastLoad` (по умолчанию `leastPing`)
+- `balancer_probe_url` и `balancer_probe_interval` используются для `leastPing/leastLoad`
 
 ### 3) Запуск
 
@@ -117,6 +125,11 @@ curl "http://HOST:8080/sub/<token>?profile=mobile"
 - `PUT /api/routes/global`
 - `DELETE /api/routes/global`
 
+### Балансировщик (runtime override)
+
+- `GET /api/config/balancer`
+- `PUT /api/config/balancer`
+
 ### Inbounds и sync
 
 - `GET /api/inbounds`
@@ -161,6 +174,22 @@ curl -X POST "http://HOST:8080/api/routes/global" \
     "outboundTag": "proxy",
     "domain": ["geosite:ru-blocked"]
   }'
+
+# Поменять стратегию балансировки без редактирования config.json
+curl -X PUT "http://HOST:8080/api/config/balancer" \
+  -H "X-Admin-Token: TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "strategy": "leastPing",
+    "probe_url": "https://www.gstatic.com/generate_204",
+    "probe_interval": "30s"
+  }'
+
+# Сбросить runtime override и вернуться к значениям из config.json
+curl -X PUT "http://HOST:8080/api/config/balancer" \
+  -H "X-Admin-Token: TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reset": true}'
 ```
 
 ---

--- a/config.json.example
+++ b/config.json.example
@@ -5,5 +5,8 @@
   "db_path": "/var/lib/xray-subscription/db.sqlite",
   "sync_interval_seconds": 60,
   "base_url": "http://1.2.3.4:8080",
-  "admin_token": "your-secret-admin-token-here"
+  "admin_token": "your-secret-admin-token-here",
+  "balancer_strategy": "leastPing",
+  "balancer_probe_url": "https://www.gstatic.com/generate_204",
+  "balancer_probe_interval": "30s"
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -71,6 +71,8 @@ func (s *Server) Router() http.Handler {
 	api.HandleFunc("/routes/global", s.setGlobalRoutes).Methods(http.MethodPut)
 	api.HandleFunc("/routes/global", s.addGlobalRoute).Methods(http.MethodPost)
 	api.HandleFunc("/routes/global", s.deleteGlobalRoutes).Methods(http.MethodDelete)
+	api.HandleFunc("/config/balancer", s.getBalancerConfig).Methods(http.MethodGet)
+	api.HandleFunc("/config/balancer", s.setBalancerConfig).Methods(http.MethodPut)
 	api.HandleFunc("/sync", s.triggerSync).Methods(http.MethodPost)
 
 	// Health check
@@ -162,7 +164,22 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg, err := xray.GenerateClientConfig(s.cfg.ServerHost, *user, clients, globalRoutesJSON)
+	balancerStrategy, balancerProbeURL, balancerProbeInterval, err := s.getEffectiveBalancerConfig()
+	if err != nil {
+		log.Printf("ERROR get balancer config: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	cfg, err := xray.GenerateClientConfig(
+		s.cfg.ServerHost,
+		*user,
+		clients,
+		globalRoutesJSON,
+		balancerStrategy,
+		balancerProbeURL,
+		balancerProbeInterval,
+	)
 	if err != nil {
 		log.Printf("ERROR generate config for %s: %v", user.Username, err)
 		jsonError(w, "could not generate config: "+err.Error(), http.StatusInternalServerError)
@@ -808,6 +825,91 @@ func (s *Server) deleteGlobalRoutes(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) getBalancerConfig(w http.ResponseWriter, r *http.Request) {
+	effectiveStrategy, effectiveProbeURL, effectiveProbeInterval, err := s.getEffectiveBalancerConfig()
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	override, err := s.db.GetBalancerRuntimeConfig()
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	source := "config"
+	if override != nil {
+		source = "runtime"
+	}
+	jsonOK(w, map[string]interface{}{
+		"source": source,
+		"effective": map[string]string{
+			"strategy":      effectiveStrategy,
+			"probe_url":     effectiveProbeURL,
+			"probe_interval": effectiveProbeInterval,
+		},
+		"config_file_defaults": map[string]string{
+			"strategy":      s.cfg.BalancerStrategy,
+			"probe_url":     s.cfg.BalancerProbeURL,
+			"probe_interval": s.cfg.BalancerProbeFreq,
+		},
+		"runtime_override": override,
+	})
+}
+
+func (s *Server) setBalancerConfig(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Strategy      string `json:"strategy"`
+		ProbeURL      string `json:"probe_url"`
+		ProbeInterval string `json:"probe_interval"`
+		Reset         bool   `json:"reset"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+	if req.Reset {
+		if err := s.db.DeleteBalancerRuntimeConfig(); err != nil {
+			jsonError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		jsonOK(w, map[string]interface{}{
+			"status": "reset_to_config_defaults",
+		})
+		return
+	}
+
+	strategy := normalizeBalancerStrategyInput(req.Strategy)
+	if strategy == "" {
+		jsonError(w, "strategy must be one of: random, leastPing, leastLoad", http.StatusBadRequest)
+		return
+	}
+	probeURL := strings.TrimSpace(req.ProbeURL)
+	if probeURL == "" {
+		probeURL = s.cfg.BalancerProbeURL
+	}
+	probeInterval := strings.TrimSpace(req.ProbeInterval)
+	if probeInterval == "" {
+		probeInterval = s.cfg.BalancerProbeFreq
+	}
+
+	if err := s.db.SetBalancerRuntimeConfig(database.BalancerRuntimeConfig{
+		Strategy:      strategy,
+		ProbeURL:      probeURL,
+		ProbeInterval: probeInterval,
+	}); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]interface{}{
+		"status": "ok",
+		"runtime_override": map[string]string{
+			"strategy":      strategy,
+			"probe_url":     probeURL,
+			"probe_interval": probeInterval,
+		},
+	})
+}
+
 func (s *Server) getUserClients(w http.ResponseWriter, r *http.Request) {
 	user, err := s.getByID(w, r)
 	if user == nil || err != nil {
@@ -1085,6 +1187,33 @@ func decodeUserRouteFromBody(body io.Reader) (models.UserRouteRule, error) {
 		return wrapped.Rule, nil
 	}
 	return models.UserRouteRule{}, fmt.Errorf("invalid json body")
+}
+
+func (s *Server) getEffectiveBalancerConfig() (strategy string, probeURL string, probeInterval string, err error) {
+	override, err := s.db.GetBalancerRuntimeConfig()
+	if err != nil {
+		return "", "", "", err
+	}
+	if override != nil {
+		return firstNonEmptyString(strings.TrimSpace(override.Strategy), s.cfg.BalancerStrategy),
+			firstNonEmptyString(strings.TrimSpace(override.ProbeURL), s.cfg.BalancerProbeURL),
+			firstNonEmptyString(strings.TrimSpace(override.ProbeInterval), s.cfg.BalancerProbeFreq),
+			nil
+	}
+	return s.cfg.BalancerStrategy, s.cfg.BalancerProbeURL, s.cfg.BalancerProbeFreq, nil
+}
+
+func normalizeBalancerStrategyInput(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "random":
+		return "random"
+	case "leastping":
+		return "leastPing"
+	case "leastload":
+		return "leastLoad"
+	default:
+		return ""
+	}
 }
 
 func assignRouteIDs(rules []models.UserRouteRule) bool {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -168,6 +168,9 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "could not generate config: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if isMobileProfileRequest(r) {
+		applyMobileRoutingProfile(cfg)
+	}
 
 	format := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("format")))
 	if format == "v2box" || format == "links" || format == "links.txt" {
@@ -925,6 +928,61 @@ func generateToken() string {
 	return hex.EncodeToString(b)
 }
 
+func isMobileProfileRequest(r *http.Request) bool {
+	profile := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("profile")))
+	if profile == "mobile" {
+		return true
+	}
+	mobile := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("mobile")))
+	if mobile == "1" || mobile == "true" || mobile == "yes" {
+		return true
+	}
+	ua := strings.ToLower(r.UserAgent())
+	return strings.Contains(ua, "android") ||
+		strings.Contains(ua, "iphone") ||
+		strings.Contains(ua, "ipad") ||
+		strings.Contains(ua, "v2box") ||
+		strings.Contains(ua, "v2rayng") ||
+		strings.Contains(ua, "nekobox")
+}
+
+func applyMobileRoutingProfile(cfg *xray.ClientConfig) {
+	if cfg == nil || cfg.Routing == nil {
+		return
+	}
+	rules := make([]xray.RoutingRule, 0, len(cfg.Routing.Rules))
+	for _, rule := range cfg.Routing.Rules {
+		rule.Domain = stripGeoSelectors(rule.Domain)
+		rule.IP = stripGeoSelectors(rule.IP)
+		// Keep only effective rules after stripping geo selectors.
+		if len(rule.Domain) == 0 &&
+			len(rule.IP) == 0 &&
+			strings.TrimSpace(rule.Network) == "" &&
+			strings.TrimSpace(rule.Port) == "" &&
+			len(rule.Protocol) == 0 &&
+			len(rule.InboundTag) == 0 {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	cfg.Routing.Rules = rules
+}
+
+func stripGeoSelectors(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		s := strings.ToLower(strings.TrimSpace(v))
+		if strings.HasPrefix(s, "geosite:") || strings.HasPrefix(s, "geoip:") {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
 func parseUserRoutes(raw string) ([]models.UserRouteRule, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -961,6 +1019,31 @@ func validateUserRoutes(rules []models.UserRouteRule) error {
 		}
 		if rule.Type != "" && strings.ToLower(strings.TrimSpace(rule.Type)) != "field" {
 			return fmt.Errorf("rules[%d].type must be 'field' or empty", i)
+		}
+		if err := validateRouteSelectors(rule); err != nil {
+			return fmt.Errorf("rules[%d] %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateRouteSelectors(rule models.UserRouteRule) error {
+	for _, d := range rule.Domain {
+		v := strings.TrimSpace(strings.ToLower(d))
+		if strings.HasPrefix(v, "geoip:") {
+			return fmt.Errorf("domain contains geoip selector %q; use ip:[\"geoip:...\"]", d)
+		}
+		if strings.HasPrefix(v, "geositeip:") {
+			return fmt.Errorf("invalid selector %q; use geosite:... in domain or geoip:... in ip", d)
+		}
+	}
+	for _, ip := range rule.IP {
+		v := strings.TrimSpace(strings.ToLower(ip))
+		if strings.HasPrefix(v, "geosite:") {
+			return fmt.Errorf("ip contains geosite selector %q; use domain:[\"geosite:...\"]", ip)
+		}
+		if strings.HasPrefix(v, "geositeip:") {
+			return fmt.Errorf("invalid selector %q; use geosite:... in domain or geoip:... in ip", ip)
 		}
 	}
 	return nil

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -56,7 +56,21 @@ func (s *Server) handleSubscriptionLinksByFormat(w http.ResponseWriter, r *http.
 		jsonError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	cfg, err := xray.GenerateClientConfig(s.cfg.ServerHost, *user, clients, globalRoutesJSON)
+	balancerStrategy, balancerProbeURL, balancerProbeInterval, err := s.getEffectiveBalancerConfig()
+	if err != nil {
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	cfg, err := xray.GenerateClientConfig(
+		s.cfg.ServerHost,
+		*user,
+		clients,
+		globalRoutesJSON,
+		balancerStrategy,
+		balancerProbeURL,
+		balancerProbeInterval,
+	)
 	if err != nil {
 		jsonError(w, "could not generate config: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,16 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 type Config struct {
-	ListenAddr    string `json:"listen_addr"`
-	ServerHost    string `json:"server_host"`
-	ConfigDir     string `json:"config_dir"`
-	DBPath        string `json:"db_path"`
-	SyncInterval  int    `json:"sync_interval_seconds"`
-	BaseURL       string `json:"base_url"`
-	AdminToken    string `json:"admin_token"`
+	ListenAddr        string `json:"listen_addr"`
+	ServerHost        string `json:"server_host"`
+	ConfigDir         string `json:"config_dir"`
+	DBPath            string `json:"db_path"`
+	SyncInterval      int    `json:"sync_interval_seconds"`
+	BaseURL           string `json:"base_url"`
+	AdminToken        string `json:"admin_token"`
+	BalancerStrategy  string `json:"balancer_strategy"`
+	BalancerProbeURL  string `json:"balancer_probe_url"`
+	BalancerProbeFreq string `json:"balancer_probe_interval"`
 }
 
 func Load(path string) (*Config, error) {
@@ -23,6 +27,10 @@ func Load(path string) (*Config, error) {
 		DBPath:       "/var/lib/xray-subscription/db.sqlite",
 		SyncInterval: 60,
 		BaseURL:      "http://localhost:8080",
+		// Supported values: random, leastPing, leastLoad
+		BalancerStrategy:  "leastPing",
+		BalancerProbeURL:  "https://www.gstatic.com/generate_204",
+		BalancerProbeFreq: "30s",
 	}
 
 	if path == "" {
@@ -44,9 +52,27 @@ func Load(path string) (*Config, error) {
 	if cfg.ServerHost == "" {
 		return nil, fmt.Errorf("server_host is required in config")
 	}
+	cfg.BalancerStrategy = normalizeBalancerStrategy(cfg.BalancerStrategy)
+	if cfg.BalancerStrategy == "" {
+		return nil, fmt.Errorf("invalid balancer_strategy: must be one of random, leastPing, leastLoad")
+	}
 	return cfg, nil
 }
 
 func (c *Config) SubURL(token string) string {
 	return fmt.Sprintf("%s/sub/%s", c.BaseURL, token)
+}
+
+func normalizeBalancerStrategy(v string) string {
+	s := strings.ToLower(strings.TrimSpace(v))
+	switch s {
+	case "", "leastping":
+		return "leastPing"
+	case "random":
+		return "random"
+	case "leastload":
+		return "leastLoad"
+	default:
+		return ""
+	}
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,12 @@ import (
 
 type DB struct {
 	conn *sql.DB
+}
+
+type BalancerRuntimeConfig struct {
+	Strategy     string `json:"strategy"`
+	ProbeURL     string `json:"probe_url"`
+	ProbeInterval string `json:"probe_interval"`
 }
 
 func New(path string) (*DB, error) {
@@ -220,6 +227,41 @@ func (db *DB) UpdateGlobalClientRoutes(routesJSON string) error {
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		routesJSON,
 	)
+	return err
+}
+
+func (db *DB) GetBalancerRuntimeConfig() (*BalancerRuntimeConfig, error) {
+	var raw string
+	err := db.conn.QueryRow(`SELECT value FROM app_settings WHERE key = 'balancer_runtime_config'`).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cfg BalancerRuntimeConfig
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (db *DB) SetBalancerRuntimeConfig(cfg BalancerRuntimeConfig) error {
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	_, err = db.conn.Exec(
+		`INSERT INTO app_settings (key, value)
+		 VALUES ('balancer_runtime_config', ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		string(raw),
+	)
+	return err
+}
+
+func (db *DB) DeleteBalancerRuntimeConfig() error {
+	_, err := db.conn.Exec(`DELETE FROM app_settings WHERE key = 'balancer_runtime_config'`)
 	return err
 }
 

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GenerateClientConfig produces a complete xray client JSON config for a user
-func GenerateClientConfig(serverHost string, user models.User, clients []models.UserClientFull, globalRoutesJSON string) (*ClientConfig, error) {
+func GenerateClientConfig(serverHost string, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string) (*ClientConfig, error) {
 	cfg := &ClientConfig{
 		Log: &LogConfig{LogLevel: "warning"},
 		DNS: defaultDNS(),
@@ -50,11 +50,25 @@ func GenerateClientConfig(serverHost string, user models.User, clients []models.
 
 	// Update routing: use balancer if multiple proxies, single proxy otherwise
 	if len(proxyTags) > 1 {
+		strategy := normalizeBalancerStrategy(balancerStrategy)
+		if strategy == "" {
+			strategy = "leastPing"
+		}
 		// Xray load balancing is configured in routing.balancers, not as an outbound protocol.
 		cfg.Routing.Balancers = append(cfg.Routing.Balancers, Balancer{
 			Tag:      "proxy-balance",
 			Selector: proxyTags,
+			Strategy: &BalancerStrategy{Type: strategy},
+			// If balancer cannot pick a healthy outbound yet, use first proxy as fallback.
+			FallbackTag: proxyTags[0],
 		})
+		if strategy == "leastPing" || strategy == "leastLoad" {
+			cfg.Observatory = &ObservatoryConfig{
+				SubjectSelector: proxyTags,
+				ProbeURL:        firstNonEmpty(strings.TrimSpace(balancerProbeURL), "https://www.gstatic.com/generate_204"),
+				ProbeInterval:   firstNonEmpty(strings.TrimSpace(balancerProbeInterval), "30s"),
+			}
+		}
 		resolveProxyRouteTargets(cfg.Routing, true, "proxy-balance")
 		cfg.Routing.Rules = append(cfg.Routing.Rules, RoutingRule{
 			Type:        "field",
@@ -72,6 +86,19 @@ func GenerateClientConfig(serverHost string, user models.User, clients []models.
 	}
 
 	return cfg, nil
+}
+
+func normalizeBalancerStrategy(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "random":
+		return "random"
+	case "leastping":
+		return "leastPing"
+	case "leastload":
+		return "leastLoad"
+	default:
+		return ""
+	}
 }
 
 func applyUserRoutes(cfg *ClientConfig, routesJSON string) {

--- a/internal/xray/parser.go
+++ b/internal/xray/parser.go
@@ -172,6 +172,9 @@ func extractVLESS(si ServerInbound) ([]ParsedClient, error) {
 			ID:       c.ID,
 			Flow:     c.Flow,
 			Email:    c.Email,
+			// For VLESS outbound users this is expected to be "none".
+			// Read from inbound settings.decryption when present, fallback to "none".
+			Encryption: firstNonEmpty(s.Decryption, "none"),
 		}
 		b, _ := json.Marshal(cred)
 		identity := firstNonEmpty(c.Email, c.ID)

--- a/internal/xray/types.go
+++ b/internal/xray/types.go
@@ -191,7 +191,15 @@ type ClientConfig struct {
 	DNS       *DNSConfig `json:"dns"`
 	Inbounds  []Inbound  `json:"inbounds"`
 	Outbounds []Outbound `json:"outbounds"`
+	Observatory *ObservatoryConfig `json:"observatory,omitempty"`
 	Routing   *Routing   `json:"routing"`
+}
+
+type ObservatoryConfig struct {
+	SubjectSelector   []string `json:"subjectSelector,omitempty"`
+	ProbeURL          string   `json:"probeURL,omitempty"`
+	ProbeInterval     string   `json:"probeInterval,omitempty"`
+	EnableConcurrency bool     `json:"enableConcurrency,omitempty"`
 }
 
 type LogConfig struct {
@@ -314,8 +322,14 @@ type Routing struct {
 }
 
 type Balancer struct {
-	Tag      string   `json:"tag"`
-	Selector []string `json:"selector"`
+	Tag         string            `json:"tag"`
+	Selector    []string          `json:"selector"`
+	Strategy    *BalancerStrategy `json:"strategy,omitempty"`
+	FallbackTag string            `json:"fallbackTag,omitempty"`
+}
+
+type BalancerStrategy struct {
+	Type string `json:"type"`
 }
 
 type RoutingRule struct {


### PR DESCRIPTION
…entation

- Added support for a mobile profile in the subscription API, allowing users to strip `geosite:` and `geoip:` selectors from routing rules.
- Introduced query parameters `?profile=mobile` and `?mobile=1` to facilitate mobile-friendly configurations.
- Updated README files to document the new mobile profile features and provide usage examples.

These changes enhance the flexibility of the subscription service for mobile users and improve the clarity of the documentation.