### PR TITLE
Enhance Makefile and GitHub Actions for multi-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,24 +100,40 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Build Linux amd64
-        run: |
-          make build-linux-amd64
-          mv build/xray-subscription-linux-amd64 xray-subscription-linux-amd64
+      - name: Build all platforms
+        run: make build-all
 
-      - name: Upload Linux binary
+      - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: xray-subscription-linux-amd64
-          path: xray-subscription-linux-amd64
+          name: xray-subscription-binaries
+          path: build/xray-subscription-*
           retention-days: 30
 
-      - name: Upload release asset
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: xray-subscription-linux-amd64
+          files: build/xray-subscription-*
           generate_release_notes: true
+          body: |
+            ## Installation
+
+            ### Linux (amd64)
+            ```bash
+            curl -Lo xray-subscription https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/xray-subscription-linux-amd64
+            chmod +x xray-subscription
+            sudo mv xray-subscription /usr/local/bin/
+            ```
+
+            ### Linux (arm64 / Raspberry Pi 4+)
+            ```bash
+            curl -Lo xray-subscription https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/xray-subscription-linux-arm64
+            chmod +x xray-subscription
+            sudo mv xray-subscription /usr/local/bin/
+            ```
+
+            See [README](https://github.com/${{ github.repository }}#readme) for full setup instructions.
 
   docker:
     name: Build & Push Docker image

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ BUILD_DIR=./build
 VERSION=$(shell git describe --tags --always 2>/dev/null || echo "dev")
 LDFLAGS=-ldflags "-s -w -X main.version=$(VERSION)"
 
-.PHONY: all build install clean deps docker-test-up docker-test-down docker-test-logs docker-test-e2e
+.PHONY: all build install clean deps release \
+        build-linux-amd64 build-linux-arm64 build-linux-arm build-darwin-amd64 build-darwin-arm64 build-all \
+        docker-test-up docker-test-down docker-test-logs docker-test-e2e
 
 all: build
 
@@ -18,6 +20,34 @@ build: deps
 build-linux-amd64: deps
 	mkdir -p $(BUILD_DIR)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY)-linux-amd64 .
+
+build-linux-arm64: deps
+	mkdir -p $(BUILD_DIR)
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY)-linux-arm64 .
+
+build-linux-arm: deps
+	mkdir -p $(BUILD_DIR)
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY)-linux-arm .
+
+build-darwin-amd64: deps
+	mkdir -p $(BUILD_DIR)
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY)-darwin-amd64 .
+
+build-darwin-arm64: deps
+	mkdir -p $(BUILD_DIR)
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY)-darwin-arm64 .
+
+build-all: build-linux-amd64 build-linux-arm64 build-linux-arm build-darwin-amd64 build-darwin-arm64
+
+# release: tag, build all platforms, push tag → triggers CI release workflow
+# Usage: make release VERSION=v0.1.0
+release:
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=v0.1.0"; exit 1; fi
+	@echo "Releasing $(VERSION)..."
+	go test ./... -race -timeout 2m -count=1
+	git tag $(VERSION)
+	git push origin $(VERSION)
+	@echo "Tag $(VERSION) pushed. GitHub Actions will build and publish the release."
 
 install: build
 	install -Dm755 $(BUILD_DIR)/$(BINARY) /usr/local/bin/$(BINARY)


### PR DESCRIPTION
- Added new build targets in the Makefile for Linux (arm64, arm) and Darwin (amd64, arm64) platforms.
- Introduced a 'build-all' target to streamline building for all platforms.
- Updated GitHub Actions workflow to build all platforms and upload binaries as artifacts.
- Enhanced release notes in the GitHub release process to include installation instructions for different platforms.

## Description

<!-- What does this PR do? Why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behaviour change)
- [x] CI / tooling
- [ ] Documentation

## Pre-PR checklist

- [x] `go test ./... -race -timeout 2m` passes locally
- [ ] `golangci-lint run` passes (or new suppressions are justified in comments)
- [ ] No secrets, real hostnames, or real tokens committed
- [ ] `docker/xray-subscription/config.json` contains only placeholder values

## Notes for reviewer

<!-- Anything that needs special attention, trade-offs, known limitations -->
