### PR TITLE
Fix sync lifecycle and parser/test consistency gaps.

### DIFF
--- a/integration/docker_compose_api_test.go
+++ b/integration/docker_compose_api_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -336,6 +337,10 @@ func exerciseSubscriptions(t *testing.T, env *composeTestEnv, st *apiState) {
 	env.subStatus(t, st.aliceToken, "/protocol/vless", http.StatusOK)
 	env.subStatus(t, st.aliceToken, "/protocol/vless/links.txt", http.StatusOK)
 	env.subStatus(t, st.aliceToken, "/protocol/vless/links.b64", http.StatusOK)
+	escapedInboundTag := url.PathEscape(st.inboundTag)
+	env.subStatus(t, st.aliceToken, "/inbound/"+escapedInboundTag, http.StatusOK)
+	env.subStatus(t, st.aliceToken, "/inbound/"+escapedInboundTag+"/links.txt", http.StatusOK)
+	env.subStatus(t, st.aliceToken, "/inbound/"+escapedInboundTag+"/links.b64", http.StatusOK)
 
 	// Protocol-specific endpoints not present in test config should return 404.
 	env.subStatus(t, st.aliceToken, "/vmess", http.StatusNotFound)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -161,11 +161,13 @@ func (db *DB) ListUsersPaginated(limit, offset int) ([]models.User, error) {
 	query := `SELECT id, username, token, enabled, client_routes, created_at, updated_at FROM users ORDER BY created_at`
 	var args []interface{}
 	if limit > 0 {
-		query += ` LIMIT ?`
-		args = append(args, limit)
-	}
-	if offset > 0 {
-		query += ` OFFSET ?`
+		query += ` LIMIT ? OFFSET ?`
+		if offset < 0 {
+			offset = 0
+		}
+		args = append(args, limit, offset)
+	} else if offset > 0 {
+		query += ` LIMIT -1 OFFSET ?`
 		args = append(args, offset)
 	}
 	rows, err := db.conn.Query(query, args...)
@@ -344,11 +346,13 @@ func (db *DB) ListInboundsPaginated(limit, offset int) ([]models.Inbound, error)
 	query := `SELECT id, tag, protocol, port, config_file, raw_config, updated_at FROM inbounds ORDER BY tag`
 	var args []interface{}
 	if limit > 0 {
-		query += ` LIMIT ?`
-		args = append(args, limit)
-	}
-	if offset > 0 {
-		query += ` OFFSET ?`
+		query += ` LIMIT ? OFFSET ?`
+		if offset < 0 {
+			offset = 0
+		}
+		args = append(args, limit, offset)
+	} else if offset > 0 {
+		query += ` LIMIT -1 OFFSET ?`
 		args = append(args, offset)
 	}
 	rows, err := db.conn.Query(query, args...)

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -2,6 +2,7 @@
 package syncer
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -24,10 +25,10 @@ func New(cfg *config.Config, db *database.DB) *Syncer {
 	return &Syncer{cfg: cfg, db: db}
 }
 
-// Start begins periodic sync + file-watch based sync
-func (s *Syncer) Start() {
+// Start begins periodic sync + file-watch based sync until ctx is done.
+func (s *Syncer) Start(ctx context.Context) {
 	// File watcher
-	go s.watch()
+	go s.watch(ctx)
 
 	// Periodic sync as fallback
 	interval := time.Duration(s.cfg.SyncInterval) * time.Second
@@ -37,14 +38,19 @@ func (s *Syncer) Start() {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		if err := s.Sync(); err != nil {
-			log.Printf("Periodic sync error: %v", err)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.Sync(); err != nil {
+				log.Printf("Periodic sync error: %v", err)
+			}
 		}
 	}
 }
 
-func (s *Syncer) watch() {
+func (s *Syncer) watch(ctx context.Context) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Printf("fsnotify init error: %v", err)
@@ -64,9 +70,12 @@ func (s *Syncer) watch() {
 	log.Printf("Watching %s for changes", s.cfg.ConfigDir)
 	debounce := time.NewTimer(0)
 	<-debounce.C // drain initial fire
+	defer debounce.Stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return

--- a/internal/xray/parser_test.go
+++ b/internal/xray/parser_test.go
@@ -332,3 +332,27 @@ func TestFirstNonEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestStoredClientConfigUnmarshalAlterIDBackwardCompat(t *testing.T) {
+	t.Run("camelCase alterId", func(t *testing.T) {
+		var c StoredClientConfig
+		err := json.Unmarshal([]byte(`{"protocol":"vmess","id":"abc","alterId":7}`), &c)
+		if err != nil {
+			t.Fatalf("unmarshal camelCase alterId: %v", err)
+		}
+		if c.AlterId != 7 {
+			t.Fatalf("expected AlterId=7, got %d", c.AlterId)
+		}
+	})
+
+	t.Run("snake_case alter_id", func(t *testing.T) {
+		var c StoredClientConfig
+		err := json.Unmarshal([]byte(`{"protocol":"vmess","id":"abc","alter_id":9}`), &c)
+		if err != nil {
+			t.Fatalf("unmarshal snake_case alter_id: %v", err)
+		}
+		if c.AlterId != 9 {
+			t.Fatalf("expected AlterId=9, got %d", c.AlterId)
+		}
+	})
+}

--- a/internal/xray/types.go
+++ b/internal/xray/types.go
@@ -405,3 +405,29 @@ type StoredClientConfig struct {
 	// SOCKS
 	User string `json:"user,omitempty"`
 }
+
+// UnmarshalJSON keeps backward compatibility for VMess alterId naming.
+// Some stored records may contain "alterId" while newer records use "alter_id".
+func (s *StoredClientConfig) UnmarshalJSON(data []byte) error {
+	type alias StoredClientConfig
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*s = StoredClientConfig(a)
+
+	// Backward compatibility: accept camelCase key if snake_case is absent.
+	if s.AlterId == 0 {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return nil
+		}
+		if v, ok := raw["alterId"]; ok {
+			var alterID int
+			if err := json.Unmarshal(v, &alterID); err == nil {
+				s.AlterId = alterID
+			}
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -57,7 +57,9 @@ func main() {
 	srv := api.NewServer(cfg, db, sync)
 
 	// Start background sync
-	go sync.Start()
+	syncCtx, syncCancel := context.WithCancel(context.Background())
+	defer syncCancel()
+	go sync.Start(syncCtx)
 
 	// ── HTTP Server ─────────────────────────────────────────────────────────
 	httpServer := &http.Server{
@@ -81,6 +83,7 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	log.Println("Shutting down...")
+	syncCancel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/testdata/xray/config.d/02_vmess.json
+++ b/testdata/xray/config.d/02_vmess.json
@@ -1,0 +1,76 @@
+{
+  "log": {
+    "access": "/var/log/xray/access.log",
+    "error": "/var/log/xray/error.log",
+    "loglevel": "warning"
+  },
+  "inbounds": [
+    {
+      "tag": "vmess-tcp",
+      "port": "18444",
+      "listen": "0.0.0.0",
+      "protocol": "vmess",
+      "settings": {
+        "clients": [
+          {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "alterId": 0,
+            "email": "vmess-tcp-user@example.com"
+          },
+          {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "alterId": 0,
+            "email": "vmess-tcp-user2@example.com"
+          }
+        ]
+      },
+      "streamSettings": {
+        "network": "tcp",
+        "security": "tls",
+        "tlsSettings": {
+          "certificates": [
+            {
+              "certificateFile": "/etc/xray/cert.pem",
+              "keyFile": "/etc/xray/key.pem",
+              "ocspStapling": 3600
+            }
+          ]
+        }
+      },
+      "sniffing": {
+        "enabled": true,
+        "destOverride": ["http", "tls"],
+        "metadata": {
+          "host": "vmess.example.com"
+        }
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "protocol": "freedom",
+      "settings": {},
+      "tag": "direct"
+    },
+    {
+      "protocol": "blackhole",
+      "settings": {},
+      "tag": "blocked"
+    }
+  ],
+  "routing": {
+    "domainStrategy": "AsIs",
+    "rules": [
+      {
+        "type": "field",
+        "ip": ["geoip:private"],
+        "outboundTag": "blocked"
+      },
+      {
+        "type": "field",
+        "domain": ["geosite:category-ads-all"],
+        "outboundTag": "blocked"
+      }
+    ]
+  }
+}

--- a/testdata/xray/config.d/03_trojan.json
+++ b/testdata/xray/config.d/03_trojan.json
@@ -1,0 +1,74 @@
+{
+  "log": {
+    "access": "/var/log/xray/access.log",
+    "error": "/var/log/xray/error.log",
+    "loglevel": "warning"
+  },
+  "inbounds": [
+    {
+      "tag": "trojan-tcp",
+      "port": "18445",
+      "listen": "0.0.0.0",
+      "protocol": "trojan",
+      "settings": {
+        "clients": [
+          {
+            "password": "trojan-password-123",
+            "email": "trojan-user1@example.com"
+          },
+          {
+            "password": "trojan-password-456",
+            "email": "trojan-user2@example.com"
+          }
+        ]
+      },
+      "streamSettings": {
+        "network": "tcp",
+        "security": "tls",
+        "tlsSettings": {
+          "certificates": [
+            {
+              "certificateFile": "/etc/xray/cert.pem",
+              "keyFile": "/etc/xray/key.pem",
+              "ocspStapling": 3600
+            }
+          ]
+        }
+      },
+      "sniffing": {
+        "enabled": true,
+        "destOverride": ["http", "tls"],
+        "metadata": {
+          "host": "trojan.example.com"
+        }
+      }
+    }
+  ],
+  "outbounds": [
+    {
+      "protocol": "freedom",
+      "settings": {},
+      "tag": "direct"
+    },
+    {
+      "protocol": "blackhole",
+      "settings": {},
+      "tag": "blocked"
+    }
+  ],
+  "routing": {
+    "domainStrategy": "AsIs",
+    "rules": [
+      {
+        "type": "field",
+        "ip": ["geoip:private"],
+        "outboundTag": "blocked"
+      },
+      {
+        "type": "field",
+        "domain": ["geosite:category-ads-all"],
+        "outboundTag": "blocked"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add graceful syncer shutdown via context, restore VMess alterId backward compatibility, normalize pagination offset handling, extend E2E coverage for inbound links endpoints, and add VMess/Trojan parser testdata for non-Docker unit tests.

Made-with: Cursor

## Description

<!-- What does this PR do? Why? -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behaviour change)
- [ ] CI / tooling
- [ ] Documentation

## Pre-PR checklist

- [ ] `go test ./... -race -timeout 2m` passes locally
- [ ] `golangci-lint run` passes (or new suppressions are justified in comments)
- [ ] No secrets, real hostnames, or real tokens committed
- [ ] `docker/xray-subscription/config.json` contains only placeholder values

## Notes for reviewer

<!-- Anything that needs special attention, trade-offs, known limitations -->
