### PR TITLE
docs: improve SEO — keywords in README, topics checklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,13 @@ profile.cov
 go.work
 go.work.sum
 
+# Secrets — never commit real credentials
+secrets.yml
+secrets*.yml
+vault_password.txt
+*.secret
+*.vault
+
 # env file
 .env
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ xray-subscription -config /etc/xray-subscription/config.json
 }
 ```
 
+> **Note:** `vless_client_encryption` is intentionally omitted from the example above — only add it when using VLESS Encryption (non-`"none"` decryption on the server inbound). Setting it to `false`, `"none"`, or `""` causes a parse error.
+
 ### Parameter reference
 
 #### Server
@@ -290,6 +292,7 @@ Limits requests per IP per minute. `0` = disabled. Helps prevent abuse.
 | `api_user_inbound_protocol` | `""` | Fallback when `config_dir` has no inbounds: protocol (`vless`, `vmess`, `trojan`, `shadowsocks`) to create the inbound in DB. Use when Xray configs are elsewhere. |
 | `api_user_inbound_port` | `443` | Port for the inbound when using `api_user_inbound_protocol` fallback. |
 | `xray_config_file_mode` | *(omit)* | Octal mode for JSON files Raven writes under `config_dir` (e.g. `"0644"` so another local user can read configs for testing). Default **`0600`**. Only permission bits `0`–`7` (max `0777`). |
+| `vless_client_encryption` | *(omit)* | Map of inbound tag → client-side VLESS Encryption string (Xray-core ≥ v26.2.6, PR #5067). Only needed when the inbound uses VLESS Encryption (`decryption` ≠ `"none"`). Generate both strings with `xray vlessenc`. Example: `{"vless-reality-in": "mlkem768x25519plus..."}`. When set, flow is forced to `xtls-rprx-vision` and Mux is disabled. Omit or remove entirely when not using VLESS Encryption. |
 | `xray_enabled` | `true` | Set to `false` to disable Xray config sync (suppress warnings if Xray is not installed). |
 | `singbox_config` | `""` | Path to sing-box server config file (e.g. `/etc/sing-box/config.json`). When set, Raven also syncs Hysteria2 inbounds from it. |
 | `singbox_enabled` | auto | Controls sing-box sync. Defaults to `true` when `singbox_config` is set. Set to `false` to temporarily disable without removing the path. |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Languages: **English** | [Русский](README.ru.md)
 - [Admin API](#admin-api)
 - [Routing Rules](#routing-rules)
 - [Supported Protocols & Transports](#supported-protocols--transports)
+- [sing-box / Hysteria2](#sing-box--hysteria2)
 - [Docker](#docker)
 - [Contributing](#contributing)
 
@@ -50,8 +51,8 @@ Users just add their subscription URL to any Xray-compatible client (V2RayNG, Ne
 
 ### For users
 - **Personal subscription URL** — one link that always returns the latest config
-- **Multiple formats** — full Xray JSON, plain share links, Base64-encoded links
-- **Protocol-specific links** — get only VLESS, VMess, Trojan, or Shadowsocks links
+- **Multiple formats** — full Xray JSON, sing-box JSON, plain share links, Base64-encoded links
+- **Protocol-specific links** — get only VLESS, VMess, Trojan, Shadowsocks, or Hysteria2 links
 - **Mobile-optimized configs** — auto-detected from User-Agent (Android, iPhone, NekoBox, V2RayNG) or via `?profile=mobile`
 - **Custom routing rules** — per-user rules to route specific sites directly, through proxy, or block them
 
@@ -66,7 +67,8 @@ Users just add their subscription URL to any Xray-compatible client (V2RayNG, Ne
 - **Global routing rules** — apply routing rules to all users at once
 
 ### Protocols & transports
-- **VLESS**, **VMess**, **Trojan**, **Shadowsocks**, **SOCKS**
+- **VLESS**, **VMess**, **Trojan**, **Shadowsocks**, **SOCKS** (via Xray-core)
+- **Hysteria2** (via sing-box) — QUIC-based protocol with Salamander obfuscation
 - **TCP**, **WebSocket**, **gRPC**, **HTTP/2**, **KCP**, **QUIC**, **HTTPUpgrade**, **XHTTP (SplitHTTP)**
 - **TLS** and **REALITY** security layers with automatic key derivation
 
@@ -75,26 +77,29 @@ Users just add their subscription URL to any Xray-compatible client (V2RayNG, Ne
 ## How it works
 
 ```
-/etc/xray/config.d/
-    ├── vless-reality.json   ← Xray server inbound configs
+/etc/xray/config.d/          /etc/sing-box/config.json
+    ├── vless-reality.json        └── (hysteria2 inbound)
     ├── vmess-ws.json
     └── trojan-tls.json
-           │
-           ▼
-    Raven Subscribe
-    (watches for changes)
-           │
-           ├─ Parses inbounds, discovers users
-           ├─ Stores in SQLite
-           ├─ Serves subscription URLs
-           └─ API-created users → Xray (config files or gRPC API)
-                      │
-                      ▼
-    https://your-server.com/sub/{token}
-                      │
-                      ▼
-    V2RayNG / NekoBox / Hiddify / V2Box
-    (fetches config automatically)
+           │                              │
+           └──────────────┬───────────────┘
+                          ▼
+                   Raven Subscribe
+                   (watches for changes)
+                          │
+                          ├─ Parses inbounds, discovers users
+                          ├─ Stores in SQLite
+                          ├─ Serves subscription URLs
+                          └─ API-created users → Xray (config files or gRPC API)
+                                     │
+                                     ▼
+                   https://your-server.com/sub/{token}         ← Xray JSON
+                   https://your-server.com/sub/{token}/singbox  ← sing-box JSON
+                   https://your-server.com/sub/{token}/hysteria2 ← share links
+                                     │
+                                     ▼
+                   V2RayNG / NekoBox / Hiddify / V2Box / Hysteria2 app
+                   (fetches config automatically)
 ```
 
 Each user gets a unique token. When their client fetches the subscription URL, Raven Subscribe builds a complete Xray client config on the fly — with all their enabled inbounds, routing rules, DNS settings, and balancer config.
@@ -185,13 +190,15 @@ Response:
       "links_b64":   "http://your-server:8080/sub/a3f8c2.../links.b64",
       "compact":     "http://your-server:8080/c/a3f8c2...",
       "compact_txt": "http://your-server:8080/c/a3f8c2.../links.txt",
-      "compact_b64": "http://your-server:8080/c/a3f8c2.../links.b64"
+      "compact_b64": "http://your-server:8080/c/a3f8c2.../links.b64",
+      "singbox":     "http://your-server:8080/sub/a3f8c2.../singbox",
+      "hysteria2":   "http://your-server:8080/sub/a3f8c2.../hysteria2"
     }
   }
 ]
 ```
 
-Give each user their `sub_urls.compact` URL — they add it to their VPN client and are ready to go.
+Give each user their `sub_urls.compact` URL — they add it to their VPN client and are ready to go. For Hysteria2 clients, use `sub_urls.singbox` or `sub_urls.hysteria2`.
 
 ---
 
@@ -222,7 +229,10 @@ xray-subscription -config /etc/xray-subscription/config.json
   "rate_limit_sub_per_min": 60,
   "rate_limit_admin_per_min": 30,
   "api_user_inbound_tag": "vless-reality",
-  "xray_api_addr": ""
+  "xray_api_addr": "",
+  "xray_enabled": true,
+  "singbox_config": "/etc/sing-box/config.json",
+  "singbox_enabled": true
 }
 ```
 
@@ -280,6 +290,9 @@ Limits requests per IP per minute. `0` = disabled. Helps prevent abuse.
 | `api_user_inbound_protocol` | `""` | Fallback when `config_dir` has no inbounds: protocol (`vless`, `vmess`, `trojan`, `shadowsocks`) to create the inbound in DB. Use when Xray configs are elsewhere. |
 | `api_user_inbound_port` | `443` | Port for the inbound when using `api_user_inbound_protocol` fallback. |
 | `xray_config_file_mode` | *(omit)* | Octal mode for JSON files Raven writes under `config_dir` (e.g. `"0644"` so another local user can read configs for testing). Default **`0600`**. Only permission bits `0`–`7` (max `0777`). |
+| `xray_enabled` | `true` | Set to `false` to disable Xray config sync (suppress warnings if Xray is not installed). |
+| `singbox_config` | `""` | Path to sing-box server config file (e.g. `/etc/sing-box/config.json`). When set, Raven also syncs Hysteria2 inbounds from it. |
+| `singbox_enabled` | auto | Controls sing-box sync. Defaults to `true` when `singbox_config` is set. Set to `false` to temporarily disable without removing the path. |
 
 **DB ↔ Xray sync (when `api_user_inbound_tag` is set):** The database is the source of truth. All changes propagate to Xray immediately:
 
@@ -326,12 +339,15 @@ Use `127.0.0.1` when running behind nginx/caddy as reverse proxy.
 
 ## Subscription URLs
 
-Each user has two subscription endpoints:
+Each user has several subscription endpoints:
 
 | Endpoint | Description |
 |---|---|
-| `/c/{token}` | **Primary.** Lightweight config — `geosite:`/`geoip:` selectors stripped. Works great on all devices. |
-| `/sub/{token}` | Full config with all routing rules including geo databases. |
+| `/c/{token}` | **Primary.** Lightweight Xray JSON config — `geosite:`/`geoip:` selectors stripped. Works great on all devices. |
+| `/sub/{token}` | Full Xray JSON config with all routing rules including geo databases. |
+| `/sub/{token}/singbox` | sing-box JSON config with Hysteria2 outbounds. For Hysteria2 clients. |
+| `/sub/{token}/hysteria2` | Hysteria2 share links (`hysteria2://…`), plain text. |
+| `/sub/{token}/hysteria2.b64` | Hysteria2 share links, Base64-encoded. |
 
 ### `/c/{token}` — primary endpoint (recommended)
 
@@ -358,6 +374,9 @@ Returns the complete config including `geosite:` and `geoip:` routing rules. Use
 | VMess links only | `/sub/{token}/vmess` |
 | Trojan links only | `/sub/{token}/trojan` |
 | Shadowsocks links only | `/sub/{token}/ss` |
+| Hysteria2 share links | `/sub/{token}/hysteria2` |
+| Hysteria2 share links (Base64) | `/sub/{token}/hysteria2.b64` |
+| sing-box JSON (Hysteria2) | `/sub/{token}/singbox` |
 | Specific inbound only | `/sub/{token}/inbound/{tag}` |
 | Lightweight config (explicit) | `/sub/{token}?profile=mobile` |
 
@@ -422,7 +441,9 @@ curl -H "X-Admin-Token: secret" http://localhost:8080/api/users
       "links_b64":   "http://your-server:8080/sub/abc123/links.b64",
       "compact":     "http://your-server:8080/c/abc123",
       "compact_txt": "http://your-server:8080/c/abc123/links.txt",
-      "compact_b64": "http://your-server:8080/c/abc123/links.b64"
+      "compact_b64": "http://your-server:8080/c/abc123/links.b64",
+      "singbox":     "http://your-server:8080/sub/abc123/singbox",
+      "hysteria2":   "http://your-server:8080/sub/abc123/hysteria2"
     }
   }
 ]
@@ -451,7 +472,9 @@ curl -X POST -H "X-Admin-Token: secret" -H "Content-Type: application/json" \
     "links_b64":   "http://your-server:8080/sub/xyz789/links.b64",
     "compact":     "http://your-server:8080/c/xyz789",
     "compact_txt": "http://your-server:8080/c/xyz789/links.txt",
-    "compact_b64": "http://your-server:8080/c/xyz789/links.b64"
+    "compact_b64": "http://your-server:8080/c/xyz789/links.b64",
+    "singbox":     "http://your-server:8080/sub/xyz789/singbox",
+    "hysteria2":   "http://your-server:8080/sub/xyz789/hysteria2"
   }
 }
 ```
@@ -673,13 +696,14 @@ Content-Type: application/json
 
 ### Protocols
 
-| Protocol | Share link format | Notes |
-|---|---|---|
-| VLESS | `vless://uuid@host:port?...#tag` | Supports REALITY, TLS, plain |
-| VMess | `vmess://base64(json)` | |
-| Trojan | `trojan://password@host:port?...#tag` | |
-| Shadowsocks | `ss://base64(method:pass)@host:port#tag` | Single and multi-user |
-| SOCKS | — | No share link format |
+| Protocol | Core | Share link format | Notes |
+|---|---|---|---|
+| VLESS | Xray | `vless://uuid@host:port?...#tag` | Supports REALITY, TLS, plain |
+| VMess | Xray | `vmess://base64(json)` | |
+| Trojan | Xray | `trojan://password@host:port?...#tag` | |
+| Shadowsocks | Xray | `ss://base64(method:pass)@host:port#tag` | Single and multi-user |
+| SOCKS | Xray | — | No share link format |
+| Hysteria2 | sing-box | `hysteria2://password@host:port?...#tag` | QUIC-based, Salamander obfuscation |
 
 ### Transport layers
 
@@ -700,6 +724,65 @@ Content-Type: application/json
 |---|---|
 | TLS | Strips server certificates, sets `fingerprint: chrome` by default |
 | REALITY | Auto-derives `publicKey` from server's `privateKey`, picks first `serverName` and `shortId` |
+
+---
+
+## sing-box / Hysteria2
+
+Raven Subscribe can run alongside [sing-box](https://github.com/SagerNet/sing-box) and serve Hysteria2 subscriptions from the same service.
+
+### How it works
+
+When `singbox_config` is set, Raven parses the sing-box server config, discovers Hysteria2 inbounds and their users, and stores them in the same SQLite database alongside Xray users. Each user's subscription then includes Hysteria2 endpoints in `sub_urls`.
+
+Xray sync and sing-box sync are fully independent — if one core is not installed, the other still works.
+
+### Configuration
+
+```json
+{
+  "server_host": "vpn.example.com",
+  "admin_token": "your-secret-token",
+  "base_url": "https://vpn.example.com",
+  "singbox_config": "/etc/sing-box/config.json",
+  "singbox_enabled": true,
+  "xray_enabled": true
+}
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `singbox_config` | `""` | Path to sing-box server config file. When set, Raven syncs Hysteria2 inbounds from it. |
+| `singbox_enabled` | auto | `true` when `singbox_config` is set. Set to `false` to temporarily disable without removing the path. |
+| `xray_enabled` | `true` | Set to `false` to disable Xray sync (e.g. when running sing-box only). |
+
+### Subscription endpoints for Hysteria2
+
+| Endpoint | Format | Use with |
+|---|---|---|
+| `/sub/{token}/singbox` | sing-box JSON | sing-box client, NekoBox (sing-box mode) |
+| `/sub/{token}/hysteria2` | `hysteria2://` share links | Hysteria2 app, Hiddify |
+| `/sub/{token}/hysteria2.b64` | Base64-encoded links | Clients that require encoded input |
+
+### Salamander obfuscation
+
+If your sing-box inbound has `obfs` configured, Raven automatically includes it in all generated links and configs:
+
+```json
+{
+  "type": "hysteria2",
+  "tag": "hysteria2-in",
+  "listen_port": 443,
+  "obfs": {
+    "type": "salamander",
+    "password": "your-obfs-password"
+  },
+  "users": [{"name": "alice@example.com", "password": "user-password"}],
+  "tls": {"enabled": true, "server_name": "vpn.example.com"}
+}
+```
+
+The generated `hysteria2://` link will contain `?obfs=salamander&obfs-password=...` automatically.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Languages: **English** | [Русский](README.ru.md)
 [![Forks](https://img.shields.io/github/forks/AlchemyLink/Raven-subscribe?style=flat)](https://github.com/AlchemyLink/Raven-subscribe/network/members)
 [![Hits](https://hits.dwyl.com/AlchemyLink/Raven-subscribe.svg?style=flat)](https://hits.dwyl.com/AlchemyLink/Raven-subscribe)
 
-**Subscription server for [XTLS/Xray-core](https://github.com/XTLS/Xray-core).** Reads your Xray server configs, auto-discovers users, and gives each one a personal subscription URL — so their VPN client always has the latest connection settings.
+**Self-hosted subscription server for [XTLS/Xray-core](https://github.com/XTLS/Xray-core) and [sing-box](https://github.com/SagerNet/sing-box).** Auto-discovers users from your Xray server configs and gives each one a personal subscription URL — so V2RayNG, NekoBox, Hiddify, and other VPN clients always fetch the latest connection settings automatically.
+
+Supports **VLESS, VMess, Trojan, Shadowsocks, Hysteria2**, transports **XHTTP/SplitHTTP, WebSocket, gRPC, REALITY**, and serves configs in Xray JSON, sing-box JSON, and share-link formats.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -26,6 +26,7 @@
 - [Admin API](#admin-api)
 - [Правила маршрутизации](#правила-маршрутизации)
 - [Протоколы и транспорты](#протоколы-и-транспорты)
+- [sing-box / Hysteria2](#sing-box--hysteria2)
 - [Docker](#docker)
 - [Участие в разработке](#участие-в-разработке)
 
@@ -50,8 +51,8 @@
 
 ### Для пользователей
 - **Персональная ссылка подписки** — одна ссылка, которая всегда возвращает актуальный конфиг
-- **Несколько форматов** — полный Xray JSON, обычные share-ссылки, Base64-кодировка
-- **Ссылки по протоколам** — только VLESS, только VMess, только Trojan или Shadowsocks
+- **Несколько форматов** — полный Xray JSON, sing-box JSON, обычные share-ссылки, Base64-кодировка
+- **Ссылки по протоколам** — только VLESS, только VMess, только Trojan, Shadowsocks или Hysteria2
 - **Оптимизация для мобильных** — автоматически определяется по User-Agent (Android, iPhone, NekoBox, V2RayNG) или через `?profile=mobile`
 - **Персональные правила маршрутизации** — каждый пользователь может иметь свои правила: какие сайты открывать напрямую, через прокси или блокировать
 
@@ -66,7 +67,8 @@
 - **Глобальные правила маршрутизации** — применяются сразу ко всем пользователям
 
 ### Протоколы и транспорты
-- **VLESS**, **VMess**, **Trojan**, **Shadowsocks**, **SOCKS**
+- **VLESS**, **VMess**, **Trojan**, **Shadowsocks**, **SOCKS** (через Xray-core)
+- **Hysteria2** (через sing-box) — протокол на базе QUIC с обфускацией Salamander
 - **TCP**, **WebSocket**, **gRPC**, **HTTP/2**, **KCP**, **QUIC**, **HTTPUpgrade**, **XHTTP (SplitHTTP)**
 - **TLS** и **REALITY** с автоматическим выводом публичного ключа
 
@@ -75,26 +77,29 @@
 ## Как это работает
 
 ```
-/etc/xray/config.d/
-    ├── vless-reality.json   ← серверные конфиги Xray
+/etc/xray/config.d/          /etc/sing-box/config.json
+    ├── vless-reality.json        └── (hysteria2 inbound)
     ├── vmess-ws.json
     └── trojan-tls.json
-           │
-           ▼
-    Raven Subscribe
-    (следит за изменениями)
-           │
-           ├─ Парсит inbound-ы, находит пользователей
-           ├─ Сохраняет в SQLite
-           ├─ Отдаёт ссылки подписки
-           └─ Пользователи через API → Xray (файлы или gRPC API)
-                      │
-                      ▼
-    https://ваш-сервер.com/sub/{token}
-                      │
-                      ▼
-    V2RayNG / NekoBox / Hiddify / V2Box
-    (автоматически получает конфиг)
+           │                              │
+           └──────────────┬───────────────┘
+                          ▼
+                   Raven Subscribe
+                   (следит за изменениями)
+                          │
+                          ├─ Парсит inbound-ы, находит пользователей
+                          ├─ Сохраняет в SQLite
+                          ├─ Отдаёт ссылки подписки
+                          └─ Пользователи через API → Xray (файлы или gRPC API)
+                                     │
+                                     ▼
+                   https://ваш-сервер.com/sub/{token}          ← Xray JSON
+                   https://ваш-сервер.com/sub/{token}/singbox   ← sing-box JSON
+                   https://ваш-сервер.com/sub/{token}/hysteria2 ← share-ссылки
+                                     │
+                                     ▼
+                   V2RayNG / NekoBox / Hiddify / V2Box / приложение Hysteria2
+                   (автоматически получает конфиг)
 ```
 
 Каждый пользователь получает уникальный токен. Когда его клиент обращается по ссылке подписки, Raven Subscribe собирает полный клиентский конфиг на лету — со всеми включёнными inbound-ами, правилами маршрутизации, настройками DNS и балансировщика.
@@ -184,13 +189,15 @@ curl -H "X-Admin-Token: ваш-секретный-токен" http://localhost:8
       "links_b64":   "http://ваш-сервер:8080/sub/a3f8c2.../links.b64",
       "compact":     "http://ваш-сервер:8080/c/a3f8c2...",
       "compact_txt": "http://ваш-сервер:8080/c/a3f8c2.../links.txt",
-      "compact_b64": "http://ваш-сервер:8080/c/a3f8c2.../links.b64"
+      "compact_b64": "http://ваш-сервер:8080/c/a3f8c2.../links.b64",
+      "singbox":     "http://ваш-сервер:8080/sub/a3f8c2.../singbox",
+      "hysteria2":   "http://ваш-сервер:8080/sub/a3f8c2.../hysteria2"
     }
   }
 ]
 ```
 
-Передайте каждому пользователю его `sub_urls.compact` — они добавляют её в VPN-клиент и готово.
+Передайте каждому пользователю его `sub_urls.compact` — они добавляют её в VPN-клиент и готово. Для Hysteria2-клиентов используйте `sub_urls.singbox` или `sub_urls.hysteria2`.
 
 ---
 
@@ -202,7 +209,7 @@ curl -H "X-Admin-Token: ваш-секретный-токен" http://localhost:8
 xray-subscription -config /etc/xray-subscription/config.json
 ```
 
-### Full config reference
+### Полный список параметров конфига
 
 ```json
 {
@@ -221,7 +228,10 @@ xray-subscription -config /etc/xray-subscription/config.json
   "rate_limit_sub_per_min": 60,
   "rate_limit_admin_per_min": 30,
   "api_user_inbound_tag": "vless-reality",
-  "xray_api_addr": ""
+  "xray_api_addr": "",
+  "xray_enabled": true,
+  "singbox_config": "/etc/sing-box/config.json",
+  "singbox_enabled": true
 }
 ```
 
@@ -279,6 +289,9 @@ xray-subscription -config /etc/xray-subscription/config.json
 | `api_user_inbound_protocol` | `""` | Запасной вариант, когда в `config_dir` нет inbound: протокол (`vless`, `vmess`, `trojan`, `shadowsocks`) для создания inbound в БД. Используйте, если конфиги Xray в другом месте. |
 | `api_user_inbound_port` | `443` | Порт inbound при использовании `api_user_inbound_protocol`. |
 | `xray_config_file_mode` | *(не задавать)* | Права (octal) для JSON-файлов, которые Raven пишет в `config_dir` (например `"0644"`, чтобы другой локальный пользователь мог читать конфиги при тестах). По умолчанию **`0600`**. Только биты `0`–`7` (не больше `0777`). |
+| `xray_enabled` | `true` | Установите `false` для отключения синхронизации Xray (убирает предупреждения, если Xray не установлен). |
+| `singbox_config` | `""` | Путь к серверному конфигу sing-box (например `/etc/sing-box/config.json`). При наличии Raven также синхронизирует Hysteria2 inbound-ы. |
+| `singbox_enabled` | авто | Управляет синхронизацией sing-box. По умолчанию `true`, если задан `singbox_config`. Установите `false` для временного отключения без удаления пути. |
 
 **Синхронизация БД ↔ Xray** (при заданном `api_user_inbound_tag`): База данных — источник правды. Все изменения сразу отражаются в Xray:
 
@@ -325,12 +338,15 @@ xray-subscription -config /etc/xray-subscription/config.json
 
 ## Ссылки подписки
 
-У каждого пользователя есть два эндпоинта подписки:
+У каждого пользователя есть несколько эндпоинтов подписки:
 
 | Эндпоинт | Описание |
 |---|---|
-| `/c/{token}` | **Основной.** Лёгкий конфиг — `geosite:`/`geoip:` селекторы убраны. Работает на всех устройствах. |
-| `/sub/{token}` | Полный конфиг со всеми правилами маршрутизации включая geo-базы. |
+| `/c/{token}` | **Основной.** Лёгкий Xray JSON конфиг — `geosite:`/`geoip:` селекторы убраны. Работает на всех устройствах. |
+| `/sub/{token}` | Полный Xray JSON конфиг со всеми правилами маршрутизации включая geo-базы. |
+| `/sub/{token}/singbox` | sing-box JSON конфиг с Hysteria2 outbound-ами. Для Hysteria2-клиентов. |
+| `/sub/{token}/hysteria2` | Share-ссылки Hysteria2 (`hysteria2://…`), обычный текст. |
+| `/sub/{token}/hysteria2.b64` | Share-ссылки Hysteria2, Base64-кодировка. |
 
 ### `/c/{token}` — основной эндпоинт (рекомендуется)
 
@@ -357,6 +373,9 @@ xray-subscription -config /etc/xray-subscription/config.json
 | Только VMess | `/sub/{token}/vmess` |
 | Только Trojan | `/sub/{token}/trojan` |
 | Только Shadowsocks | `/sub/{token}/ss` |
+| Только Hysteria2 share-ссылки | `/sub/{token}/hysteria2` |
+| Hysteria2 share-ссылки (Base64) | `/sub/{token}/hysteria2.b64` |
+| sing-box JSON (Hysteria2) | `/sub/{token}/singbox` |
 | Конкретный inbound по тегу | `/sub/{token}/inbound/{tag}` |
 | Лёгкий конфиг (явно) | `/sub/{token}?profile=mobile` |
 
@@ -421,7 +440,9 @@ curl -H "X-Admin-Token: secret" http://localhost:8080/api/users
       "links_b64":   "http://ваш-сервер:8080/sub/abc123/links.b64",
       "compact":     "http://ваш-сервер:8080/c/abc123",
       "compact_txt": "http://ваш-сервер:8080/c/abc123/links.txt",
-      "compact_b64": "http://ваш-сервер:8080/c/abc123/links.b64"
+      "compact_b64": "http://ваш-сервер:8080/c/abc123/links.b64",
+      "singbox":     "http://ваш-сервер:8080/sub/abc123/singbox",
+      "hysteria2":   "http://ваш-сервер:8080/sub/abc123/hysteria2"
     }
   }
 ]
@@ -450,7 +471,9 @@ curl -X POST -H "X-Admin-Token: secret" -H "Content-Type: application/json" \
     "links_b64":   "http://ваш-сервер:8080/sub/xyz789/links.b64",
     "compact":     "http://ваш-сервер:8080/c/xyz789",
     "compact_txt": "http://ваш-сервер:8080/c/xyz789/links.txt",
-    "compact_b64": "http://ваш-сервер:8080/c/xyz789/links.b64"
+    "compact_b64": "http://ваш-сервер:8080/c/xyz789/links.b64",
+    "singbox":     "http://ваш-сервер:8080/sub/xyz789/singbox",
+    "hysteria2":   "http://ваш-сервер:8080/sub/xyz789/hysteria2"
   }
 }
 ```
@@ -672,13 +695,14 @@ Content-Type: application/json
 
 ### Протоколы
 
-| Протокол | Формат share-ссылки | Примечания |
-|---|---|---|
-| VLESS | `vless://uuid@host:port?...#tag` | Поддерживает REALITY, TLS, plain |
-| VMess | `vmess://base64(json)` | |
-| Trojan | `trojan://password@host:port?...#tag` | |
-| Shadowsocks | `ss://base64(method:pass)@host:port#tag` | Одиночный и мультипользовательский |
-| SOCKS | — | Без share-ссылки |
+| Протокол | Ядро | Формат share-ссылки | Примечания |
+|---|---|---|---|
+| VLESS | Xray | `vless://uuid@host:port?...#tag` | Поддерживает REALITY, TLS, plain |
+| VMess | Xray | `vmess://base64(json)` | |
+| Trojan | Xray | `trojan://password@host:port?...#tag` | |
+| Shadowsocks | Xray | `ss://base64(method:pass)@host:port#tag` | Одиночный и мультипользовательский |
+| SOCKS | Xray | — | Без share-ссылки |
+| Hysteria2 | sing-box | `hysteria2://password@host:port?...#tag` | QUIC-протокол, обфускация Salamander |
 
 ### Транспортные слои
 
@@ -699,6 +723,65 @@ Content-Type: application/json
 |---|---|
 | TLS | Убирает серверные сертификаты, устанавливает `fingerprint: chrome` по умолчанию |
 | REALITY | Автоматически выводит `publicKey` из серверного `privateKey`, берёт первый `serverName` и `shortId` |
+
+---
+
+## sing-box / Hysteria2
+
+Raven Subscribe может работать параллельно с [sing-box](https://github.com/SagerNet/sing-box) и отдавать Hysteria2-подписки из того же сервиса.
+
+### Как это работает
+
+При заданном `singbox_config` Raven парсит серверный конфиг sing-box, находит Hysteria2 inbound-ы и их пользователей, и сохраняет их в ту же SQLite-базу рядом с Xray-пользователями. Подписка каждого пользователя автоматически включает Hysteria2-эндпоинты в `sub_urls`.
+
+Синхронизация Xray и sing-box полностью независимы — если одно ядро не установлено, второе продолжает работать.
+
+### Конфигурация
+
+```json
+{
+  "server_host": "vpn.example.com",
+  "admin_token": "ваш-секретный-токен",
+  "base_url": "https://vpn.example.com",
+  "singbox_config": "/etc/sing-box/config.json",
+  "singbox_enabled": true,
+  "xray_enabled": true
+}
+```
+
+| Параметр | По умолчанию | Описание |
+|---|---|---|
+| `singbox_config` | `""` | Путь к серверному конфигу sing-box. При наличии Raven синхронизирует Hysteria2 inbound-ы из него. |
+| `singbox_enabled` | авто | `true`, если `singbox_config` задан. Установите `false` для временного отключения без удаления пути. |
+| `xray_enabled` | `true` | Установите `false` для отключения синхронизации Xray (например, при использовании только sing-box). |
+
+### Эндпоинты подписки для Hysteria2
+
+| Эндпоинт | Формат | Для каких клиентов |
+|---|---|---|
+| `/sub/{token}/singbox` | sing-box JSON | sing-box клиент, NekoBox (режим sing-box) |
+| `/sub/{token}/hysteria2` | `hysteria2://` share-ссылки | приложение Hysteria2, Hiddify |
+| `/sub/{token}/hysteria2.b64` | Base64-кодировка | клиенты, требующие Base64 |
+
+### Обфускация Salamander
+
+Если в inbound sing-box настроен `obfs`, Raven автоматически включает его во все генерируемые ссылки и конфиги:
+
+```json
+{
+  "type": "hysteria2",
+  "tag": "hysteria2-in",
+  "listen_port": 443,
+  "obfs": {
+    "type": "salamander",
+    "password": "ваш-obfs-пароль"
+  },
+  "users": [{"name": "alice@example.com", "password": "пароль-пользователя"}],
+  "tls": {"enabled": true, "server_name": "vpn.example.com"}
+}
+```
+
+Генерируемая `hysteria2://` ссылка автоматически будет содержать `?obfs=salamander&obfs-password=...`.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -289,6 +289,7 @@ xray-subscription -config /etc/xray-subscription/config.json
 | `api_user_inbound_protocol` | `""` | Запасной вариант, когда в `config_dir` нет inbound: протокол (`vless`, `vmess`, `trojan`, `shadowsocks`) для создания inbound в БД. Используйте, если конфиги Xray в другом месте. |
 | `api_user_inbound_port` | `443` | Порт inbound при использовании `api_user_inbound_protocol`. |
 | `xray_config_file_mode` | *(не задавать)* | Права (octal) для JSON-файлов, которые Raven пишет в `config_dir` (например `"0644"`, чтобы другой локальный пользователь мог читать конфиги при тестах). По умолчанию **`0600`**. Только биты `0`–`7` (не больше `0777`). |
+| `vless_client_encryption` | *(не задавать)* | Map тег inbound → клиентская строка VLESS Encryption (Xray-core ≥ v26.2.6, PR #5067). Нужно только когда inbound использует VLESS Encryption (`decryption` ≠ `"none"`). Генерация: `xray vlessenc`. Пример: `{"vless-reality-in": "mlkem768x25519plus..."}`. При включении flow принудительно `xtls-rprx-vision`, Mux отключён. Не задавайте или удалите при стандартном VLESS. |
 | `xray_enabled` | `true` | Установите `false` для отключения синхронизации Xray (убирает предупреждения, если Xray не установлен). |
 | `singbox_config` | `""` | Путь к серверному конфигу sing-box (например `/etc/sing-box/config.json`). При наличии Raven также синхронизирует Hysteria2 inbound-ы. |
 | `singbox_enabled` | авто | Управляет синхронизацией sing-box. По умолчанию `true`, если задан `singbox_config`. Установите `false` для временного отключения без удаления пути. |

--- a/README.ru.md
+++ b/README.ru.md
@@ -11,7 +11,9 @@
 [![Forks](https://img.shields.io/github/forks/AlchemyLink/Raven-subscribe?style=flat)](https://github.com/AlchemyLink/Raven-subscribe/network/members)
 [![Hits](https://hits.dwyl.com/AlchemyLink/Raven-subscribe.svg?style=flat)](https://hits.dwyl.com/AlchemyLink/Raven-subscribe)
 
-**Сервер подписок для [XTLS/Xray-core](https://github.com/XTLS/Xray-core).** Читает конфиги вашего Xray-сервера, автоматически находит пользователей и выдаёт каждому персональную ссылку-подписку — чтобы VPN-клиент всегда получал актуальные настройки подключения.
+**Self-hosted сервер подписок для [XTLS/Xray-core](https://github.com/XTLS/Xray-core) и [sing-box](https://github.com/SagerNet/sing-box).** Автоматически находит пользователей в конфигах вашего Xray-сервера и выдаёт каждому персональную ссылку — чтобы V2RayNG, NekoBox, Hiddify и другие VPN-клиенты всегда получали актуальные настройки подключения.
+
+Поддерживает **VLESS, VMess, Trojan, Shadowsocks, Hysteria2**, транспорты **XHTTP/SplitHTTP, WebSocket, gRPC, REALITY**, отдаёт конфиги в форматах Xray JSON, sing-box JSON и share-ссылках.
 
 ---
 

--- a/docs/SEO_CHECKLIST.md
+++ b/docs/SEO_CHECKLIST.md
@@ -1,0 +1,62 @@
+# SEO & Discoverability Checklist
+
+## 1. GitHub Repository Topics
+
+Go to: https://github.com/AlchemyLink/Raven-subscribe → Settings → scroll to "Topics"
+
+Add these topics (copy-paste each):
+```
+xray xray-core vless vmess trojan shadowsocks hysteria2 subscription-server sing-box reality xhttp v2ray vpn proxy golang self-hosted
+```
+
+---
+
+## 2. GitHub Repository Description
+
+Go to: https://github.com/AlchemyLink/Raven-subscribe → Settings (gear icon next to "About")
+
+Set description to:
+```
+Self-hosted subscription server for Xray-core and sing-box. Auto-discovers users, serves personal VPN config URLs for V2RayNG, NekoBox, Hiddify, Hysteria2.
+```
+
+Set website to your server URL or leave empty.
+
+---
+
+## 3. awesome-selfhosted
+
+awesome-selfhosted is the most important list for self-hosted projects.
+Repo: https://github.com/awesome-selfhosted/awesome-selfhosted
+
+The entry to add (goes under **Proxy** section, alphabetically near "R"):
+
+```markdown
+- [Raven Subscribe](https://github.com/AlchemyLink/Raven-subscribe) - Self-hosted subscription server for Xray-core and sing-box. Auto-discovers VLESS/VMess/Trojan/Shadowsocks/Hysteria2 users from server configs and serves personal subscription URLs for V2RayNG, NekoBox, Hiddify and other clients. `MIT` `Go/Docker`
+```
+
+PR checklist (from their CONTRIBUTING.md):
+- [ ] Fork awesome-selfhosted/awesome-selfhosted
+- [ ] Add the line above in `README.md` under **Proxy** section, in alphabetical order
+- [ ] The project must have a working demo or clear screenshots (add one to your README if missing)
+- [ ] License must be in the repo (MIT — already present)
+- [ ] Must have a public source code link (already present)
+
+---
+
+## 4. awesome-v2ray / awesome-xray lists
+
+Add to: https://github.com/v2fly/awesome-v2ray
+
+Entry:
+```markdown
+- [Raven Subscribe](https://github.com/AlchemyLink/Raven-subscribe) - Self-hosted subscription server. Auto-discovers users from Xray server configs, serves Xray JSON / sing-box JSON / share links.
+```
+
+---
+
+## 5. Done automatically (this PR)
+
+- [x] README.md first paragraph rewritten with SEO keywords
+- [x] README.ru.md first paragraph rewritten with SEO keywords
+- [x] Both mention: self-hosted, Xray-core, sing-box, VLESS, VMess, Trojan, Shadowsocks, Hysteria2, XHTTP, REALITY, V2RayNG, NekoBox, Hiddify

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -57,6 +57,14 @@ func (s *Server) Router() http.Handler {
 	r.HandleFunc("/c/{token}", s.handleCompactSubscription).Methods(http.MethodGet)
 	r.HandleFunc("/c/{token}/links.txt", s.handleCompactSubscriptionLinksText).Methods(http.MethodGet)
 	r.HandleFunc("/c/{token}/links.b64", s.handleCompactSubscriptionLinksB64).Methods(http.MethodGet)
+	// ── sing-box / Hysteria2 subscription endpoints ───────────────────────────
+	// /sub/{token}/singbox      → sing-box JSON with Hysteria2 outbounds only
+	// /sub/{token}/hysteria2    → hysteria2:// share links (plain text)
+	// /sub/{token}/hysteria2.b64 → hysteria2:// share links (base64)
+	r.HandleFunc("/sub/{token}/singbox", s.handleSingboxSubscription).Methods(http.MethodGet)
+	r.HandleFunc("/sub/{token}/hysteria2", s.handleHysteria2LinksText).Methods(http.MethodGet)
+	r.HandleFunc("/sub/{token}/hysteria2.b64", s.handleHysteria2LinksB64).Methods(http.MethodGet)
+
 	r.HandleFunc("/sub/{token}/vless", s.handleVLESSLinksText).Methods(http.MethodGet)
 	r.HandleFunc("/sub/{token}/vless.b64", s.handleVLESSLinksB64).Methods(http.MethodGet)
 	r.HandleFunc("/sub/{token}/vless/list", s.handleVLESSList).Methods(http.MethodGet)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -220,6 +220,7 @@ func TestBuildHysteria2Link_NoObfs(t *testing.T) {
 		ServerPort: 443,
 		Password:   "p",
 	}
+	// #nosec G117 -- marshaling test fixture struct, not a real secret.
 	settingsJSON, _ := json.Marshal(settings)
 	ob := xray.Outbound{Tag: "t", Protocol: "hysteria2", Settings: settingsJSON}
 	link := buildHysteria2Link(ob)
@@ -230,6 +231,7 @@ func TestBuildHysteria2Link_NoObfs(t *testing.T) {
 
 func TestBuildHysteria2Link_MissingPassword_ReturnsEmpty(t *testing.T) {
 	settings := xray.Hysteria2OutboundSettings{Server: "h", ServerPort: 443}
+	// #nosec G117 -- marshaling test fixture struct, not a real secret.
 	settingsJSON, _ := json.Marshal(settings)
 	ob := xray.Outbound{Tag: "t", Protocol: "hysteria2", Settings: settingsJSON}
 	if link := buildHysteria2Link(ob); link != "" {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -172,7 +172,7 @@ func createTestUserWithHysteria2(t *testing.T, db *database.DB, username string)
 	if err != nil {
 		t.Fatalf("UpsertInbound: %v", err)
 	}
-	cred := `{"protocol":"hysteria2","password":"secret","server_name":"vpn.example.com","obfs_type":"salamander","obfs_password":"obfssecret"}`
+	cred := `{"protocol":"hysteria2","password":"secret","server_name":"vpn.example.com","obfs_type":"salamander","obfs_password":"obfssecret"}` // #nosec G101 -- test fixture, not a real credential.
 	if err := db.UpsertUserClient(user.ID, ibID, cred); err != nil {
 		t.Fatalf("UpsertUserClient: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestBuildHysteria2Link(t *testing.T) {
 		TLS:        &xray.Hysteria2TLS{Enabled: true, ServerName: "vpn.example.com"},
 		Obfs:       &xray.Hysteria2Obfs{Type: "salamander", Password: "obfssecret"},
 	}
-	settingsJSON, _ := json.Marshal(settings)
+	settingsJSON, _ := json.Marshal(settings) // #nosec G117 -- marshaling test fixture struct, not a real secret.
 	ob := xray.Outbound{
 		Tag:      "hy2-tag",
 		Protocol: "hysteria2",

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2,15 +2,19 @@ package api
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/alchemylink/raven-subscribe/internal/config"
 	"github.com/alchemylink/raven-subscribe/internal/database"
+	"github.com/alchemylink/raven-subscribe/internal/models"
+	"github.com/alchemylink/raven-subscribe/internal/xray"
 )
 
 func TestAPI_Health(t *testing.T) {
@@ -153,4 +157,237 @@ func testServer(t *testing.T) (*Server, func()) {
 type noopSyncer struct{}
 
 func (n *noopSyncer) Sync() error { return nil }
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// createTestUserWithHysteria2 creates a user and adds a hysteria2 client to DB.
+func createTestUserWithHysteria2(t *testing.T, db *database.DB, username string) (token string) {
+	t.Helper()
+	user, err := db.CreateUser(username, username, "tok-"+username)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ibID, err := db.UpsertInbound("hy2-in", "hysteria2", 8443, "singbox.json",
+		`{"type":"hysteria2","tag":"hy2-in","listen_port":8443}`)
+	if err != nil {
+		t.Fatalf("UpsertInbound: %v", err)
+	}
+	cred := `{"protocol":"hysteria2","password":"secret","server_name":"vpn.example.com","obfs_type":"salamander","obfs_password":"obfssecret"}`
+	if err := db.UpsertUserClient(user.ID, ibID, cred); err != nil {
+		t.Fatalf("UpsertUserClient: %v", err)
+	}
+	return user.Token
+}
+
+// ── buildHysteria2Link unit tests ────────────────────────────────────────────
+
+func TestBuildHysteria2Link(t *testing.T) {
+	settings := xray.Hysteria2OutboundSettings{
+		Server:     "vpn.example.com",
+		ServerPort: 8443,
+		Password:   "secret",
+		TLS:        &xray.Hysteria2TLS{Enabled: true, ServerName: "vpn.example.com"},
+		Obfs:       &xray.Hysteria2Obfs{Type: "salamander", Password: "obfssecret"},
+	}
+	settingsJSON, _ := json.Marshal(settings)
+	ob := xray.Outbound{
+		Tag:      "hy2-tag",
+		Protocol: "hysteria2",
+		Settings: settingsJSON,
+	}
+
+	link := buildHysteria2Link(ob)
+	if !strings.HasPrefix(link, "hysteria2://") {
+		t.Fatalf("link should start with hysteria2://, got %q", link)
+	}
+	if !strings.Contains(link, "obfs=salamander") {
+		t.Errorf("link should contain obfs=salamander, got %q", link)
+	}
+	if !strings.Contains(link, "sni=vpn.example.com") {
+		t.Errorf("link should contain sni, got %q", link)
+	}
+	if !strings.Contains(link, "insecure=0") {
+		t.Errorf("link should contain insecure=0, got %q", link)
+	}
+	if !strings.HasSuffix(link, "#hy2-tag") {
+		t.Errorf("link should end with #hy2-tag, got %q", link)
+	}
+}
+
+func TestBuildHysteria2Link_NoObfs(t *testing.T) {
+	settings := xray.Hysteria2OutboundSettings{
+		Server:     "vpn.example.com",
+		ServerPort: 443,
+		Password:   "p",
+	}
+	settingsJSON, _ := json.Marshal(settings)
+	ob := xray.Outbound{Tag: "t", Protocol: "hysteria2", Settings: settingsJSON}
+	link := buildHysteria2Link(ob)
+	if strings.Contains(link, "obfs") {
+		t.Errorf("link should not contain obfs without obfs config, got %q", link)
+	}
+}
+
+func TestBuildHysteria2Link_MissingPassword_ReturnsEmpty(t *testing.T) {
+	settings := xray.Hysteria2OutboundSettings{Server: "h", ServerPort: 443}
+	settingsJSON, _ := json.Marshal(settings)
+	ob := xray.Outbound{Tag: "t", Protocol: "hysteria2", Settings: settingsJSON}
+	if link := buildHysteria2Link(ob); link != "" {
+		t.Errorf("expected empty link for missing password, got %q", link)
+	}
+}
+
+func TestExcludeProtocol(t *testing.T) {
+	clients := []models.UserClientFull{
+		{InboundProtocol: "vless"},
+		{InboundProtocol: "hysteria2"},
+		{InboundProtocol: "HYSTERIA2"},
+		{InboundProtocol: "vmess"},
+	}
+	filtered := excludeProtocol(clients, "hysteria2")
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 non-hysteria2 clients, got %d", len(filtered))
+	}
+	for _, c := range filtered {
+		if strings.EqualFold(c.InboundProtocol, "hysteria2") {
+			t.Errorf("hysteria2 client leaked through excludeProtocol")
+		}
+	}
+}
+
+// ── HTTP endpoint tests ───────────────────────────────────────────────────────
+
+func TestAPI_Hysteria2LinksText_ValidToken(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+	token := createTestUserWithHysteria2(t, srv.db, "hyuser")
+
+	req := httptest.NewRequest(http.MethodGet, "/sub/"+token+"/hysteria2", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("hysteria2 links: got %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.HasPrefix(body, "hysteria2://") {
+		t.Errorf("expected hysteria2:// link, got %q", body)
+	}
+	if !strings.Contains(body, "obfs=salamander") {
+		t.Errorf("expected salamander obfs in link, got %q", body)
+	}
+}
+
+func TestAPI_Hysteria2LinksB64_ValidToken(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+	token := createTestUserWithHysteria2(t, srv.db, "hyuserb64")
+
+	req := httptest.NewRequest(http.MethodGet, "/sub/"+token+"/hysteria2.b64", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	decoded, err := base64.StdEncoding.DecodeString(rec.Body.String())
+	if err != nil {
+		t.Fatalf("response is not valid base64: %v", err)
+	}
+	if !strings.HasPrefix(string(decoded), "hysteria2://") {
+		t.Errorf("decoded payload should start with hysteria2://, got %q", decoded)
+	}
+}
+
+func TestAPI_Hysteria2Links_InvalidToken(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/sub/badtoken/hysteria2", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for bad token, got %d", rec.Code)
+	}
+}
+
+func TestAPI_SingboxSubscription_ValidToken(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+	token := createTestUserWithHysteria2(t, srv.db, "singboxuser")
+
+	req := httptest.NewRequest(http.MethodGet, "/sub/"+token+"/singbox", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("singbox sub: got %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var cfg map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode singbox response: %v", err)
+	}
+	outbounds, ok := cfg["outbounds"].([]interface{})
+	if !ok || len(outbounds) == 0 {
+		t.Fatal("expected outbounds in singbox config")
+	}
+	// First outbound should be hysteria2
+	first := outbounds[0].(map[string]interface{})
+	if first["type"] != "hysteria2" {
+		t.Errorf("first outbound type: got %v, want hysteria2", first["type"])
+	}
+	// Obfs should be present
+	obfs, ok := first["obfs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected obfs in hysteria2 outbound")
+	}
+	if obfs["type"] != "salamander" {
+		t.Errorf("obfs type: got %v, want salamander", obfs["type"])
+	}
+}
+
+func TestAPI_SingboxSubscription_InvalidToken(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/sub/badtoken/singbox", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for bad token, got %d", rec.Code)
+	}
+}
+
+func TestBuildSingboxClientConfig_Structure(t *testing.T) {
+	outbounds := []xray.Hysteria2OutboundSettings{
+		{
+			Type:       "hysteria2",
+			Tag:        "hy2-0",
+			Server:     "vpn.example.com",
+			ServerPort: 8443,
+			Password:   "secret",
+			TLS:        &xray.Hysteria2TLS{Enabled: true, ServerName: "vpn.example.com"},
+		},
+	}
+	cfg := buildSingboxClientConfig(outbounds)
+
+	obs, _ := cfg["outbounds"].([]interface{})
+	// 1 proxy + direct + block
+	if len(obs) != 3 {
+		t.Errorf("expected 3 outbounds (hy2 + direct + block), got %d", len(obs))
+	}
+	inbounds, _ := cfg["inbounds"].([]map[string]interface{})
+	if len(inbounds) != 1 {
+		t.Errorf("expected 1 inbound, got %d", len(inbounds))
+	}
+	if inbounds[0]["type"] != "mixed" {
+		t.Errorf("inbound type: got %v, want mixed", inbounds[0]["type"])
+	}
+	route := cfg["route"].(map[string]interface{})
+	if route["final"] != "hy2-0" {
+		t.Errorf("route.final: got %v, want hy2-0", route["final"])
+	}
+}
 

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -61,6 +61,14 @@ func (s *Server) handleShadowsocksLinksB64(w http.ResponseWriter, r *http.Reques
 	s.handleSubscriptionLinksByFormatAndProtocol(w, r, "b64", "shadowsocks")
 }
 
+func (s *Server) handleHysteria2LinksText(w http.ResponseWriter, r *http.Request) {
+	s.handleHysteria2LinksByFormat(w, r, "txt")
+}
+
+func (s *Server) handleHysteria2LinksB64(w http.ResponseWriter, r *http.Request) {
+	s.handleHysteria2LinksByFormat(w, r, "b64")
+}
+
 func (s *Server) handleVLESSList(w http.ResponseWriter, r *http.Request) {
 	cfg, username, err := s.generateConfigForSubscriptionRequest(r)
 	if err != nil {
@@ -258,6 +266,10 @@ func buildProxyLinkEntries(cfg *xray.ClientConfig) []proxyLink {
 			if l := buildSSLink(ob); l != "" {
 				links = append(links, proxyLink{Protocol: "shadowsocks", Tag: ob.Tag, URL: l})
 			}
+		case "hysteria2":
+			if l := buildHysteria2Link(ob); l != "" {
+				links = append(links, proxyLink{Protocol: "hysteria2", Tag: ob.Tag, URL: l})
+			}
 		}
 	}
 	return links
@@ -286,6 +298,9 @@ func (s *Server) generateConfigForSubscriptionRequestWithForcedProtocol(r *http.
 		return nil, "", fmt.Errorf("internal error")
 	}
 	clients = applySubscriptionFiltersWithProtocol(clients, r, forcedProtocol)
+	// Hysteria2 uses sing-box format — exclude from Xray JSON subscription.
+	// Hysteria2 clients are served via /sub/{token}/singbox and share links.
+	clients = excludeProtocol(clients, "hysteria2")
 	if len(clients) == 0 {
 		return nil, "", fmt.Errorf("no enabled clients matched filters")
 	}
@@ -522,5 +537,115 @@ func firstNonEmptyString(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func excludeProtocol(clients []models.UserClientFull, protocol string) []models.UserClientFull {
+	filtered := clients[:0]
+	for _, c := range clients {
+		if !strings.EqualFold(c.InboundProtocol, protocol) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+func (s *Server) handleHysteria2LinksByFormat(w http.ResponseWriter, r *http.Request, format string) {
+	token := mux.Vars(r)["token"]
+	if token == "" {
+		jsonError(w, "missing token", http.StatusBadRequest)
+		return
+	}
+	user, err := s.db.GetUserByToken(token)
+	if err != nil || user == nil {
+		jsonError(w, "invalid token", http.StatusNotFound)
+		return
+	}
+	if !user.Enabled {
+		jsonError(w, "user disabled", http.StatusForbidden)
+		return
+	}
+	clients, err := s.db.GetUserClients(user.ID)
+	if err != nil {
+		log.Printf("ERROR get user clients for hysteria2 sub %s: %v", sanitizeLogField(user.Username), err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	links := make([]string, 0)
+	for i, c := range clients {
+		if !strings.EqualFold(c.InboundProtocol, "hysteria2") {
+			continue
+		}
+		var cred xray.StoredClientConfig
+		if err := json.Unmarshal([]byte(c.ClientConfig), &cred); err != nil {
+			log.Printf("WARN: hysteria2 sub parse cred for inbound %s: %v", c.InboundTag, err)
+			continue
+		}
+		serverName := cred.ServerName
+		if serverName == "" {
+			serverName = s.cfg.ServerHost
+		}
+		tag := strings.NewReplacer(" ", "-", "/", "-", "\\", "-").Replace(c.InboundTag)
+		tag = fmt.Sprintf("%s-%d", tag, i)
+
+		params := url.Values{}
+		if serverName != "" {
+			params.Set("sni", serverName)
+		}
+		if cred.ObfsType != "" {
+			params.Set("obfs", cred.ObfsType)
+			if cred.ObfsPassword != "" {
+				params.Set("obfs-password", cred.ObfsPassword)
+			}
+		}
+		params.Set("insecure", "0")
+		link := fmt.Sprintf("hysteria2://%s@%s:%d?%s#%s",
+			url.QueryEscape(cred.Password), s.cfg.ServerHost, c.InboundPort, params.Encode(), url.QueryEscape(tag))
+		links = append(links, link)
+	}
+
+	if len(links) == 0 {
+		jsonError(w, "no hysteria2 inbounds found", http.StatusNotFound)
+		return
+	}
+
+	plain := strings.Join(links, "\n")
+	w.Header().Set("Profile-Title", user.Username)
+	w.Header().Set("Subscription-Userinfo", "upload=0; download=0; total=0; expire=0")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if format == "b64" {
+		_, _ = w.Write([]byte(base64.StdEncoding.EncodeToString([]byte(plain))))
+		return
+	}
+	_, _ = w.Write([]byte(plain))
+}
+
+func buildHysteria2Link(ob xray.Outbound) string {
+	var s xray.Hysteria2OutboundSettings
+	if err := json.Unmarshal(ob.Settings, &s); err != nil {
+		return ""
+	}
+	if s.Password == "" || s.Server == "" || s.ServerPort == 0 {
+		return ""
+	}
+	params := url.Values{}
+	if s.TLS != nil && s.TLS.ServerName != "" {
+		params.Set("sni", s.TLS.ServerName)
+	}
+	if s.Obfs != nil && s.Obfs.Type != "" {
+		params.Set("obfs", s.Obfs.Type)
+		if s.Obfs.Password != "" {
+			params.Set("obfs-password", s.Obfs.Password)
+		}
+	}
+	params.Set("insecure", "0")
+	q := params.Encode()
+	link := fmt.Sprintf("hysteria2://%s@%s:%d",
+		url.QueryEscape(s.Password), s.Server, s.ServerPort)
+	if q != "" {
+		link += "?" + q
+	}
+	link += "#" + url.QueryEscape(ob.Tag)
+	return link
 }
 

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -566,7 +566,8 @@ func (s *Server) handleHysteria2LinksByFormat(w http.ResponseWriter, r *http.Req
 	}
 	clients, err := s.db.GetUserClients(user.ID)
 	if err != nil {
-		log.Printf("ERROR get user clients for hysteria2 sub %s: %v", sanitizeLogField(user.Username), err) // #nosec G706 -- username is sanitized before logging.
+		// #nosec G706 -- username is sanitized before logging.
+		log.Printf("ERROR get user clients for hysteria2 sub %s: %v", sanitizeLogField(user.Username), err)
 		jsonError(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -566,7 +566,7 @@ func (s *Server) handleHysteria2LinksByFormat(w http.ResponseWriter, r *http.Req
 	}
 	clients, err := s.db.GetUserClients(user.ID)
 	if err != nil {
-		log.Printf("ERROR get user clients for hysteria2 sub %s: %v", sanitizeLogField(user.Username), err)
+		log.Printf("ERROR get user clients for hysteria2 sub %s: %v", sanitizeLogField(user.Username), err) // #nosec G706 -- username is sanitized before logging.
 		jsonError(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/sub_singbox.go
+++ b/internal/api/sub_singbox.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/alchemylink/raven-subscribe/internal/xray"
+)
+
+// handleSingboxSubscription serves a sing-box JSON config containing only
+// Hysteria2 outbounds for the requesting user.
+func (s *Server) handleSingboxSubscription(w http.ResponseWriter, r *http.Request) {
+	token := mux.Vars(r)["token"]
+	if token == "" {
+		jsonError(w, "missing token", http.StatusBadRequest)
+		return
+	}
+	user, err := s.db.GetUserByToken(token)
+	if err != nil || user == nil {
+		jsonError(w, "invalid token", http.StatusNotFound)
+		return
+	}
+	if !user.Enabled {
+		jsonError(w, "user disabled", http.StatusForbidden)
+		return
+	}
+	clients, err := s.db.GetUserClients(user.ID)
+	if err != nil {
+		log.Printf("ERROR get user clients for singbox sub %s: %v", sanitizeLogField(user.Username), err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	outbounds := make([]xray.Hysteria2OutboundSettings, 0)
+	for i, c := range clients {
+		if !strings.EqualFold(c.InboundProtocol, "hysteria2") {
+			continue
+		}
+		var cred xray.StoredClientConfig
+		if err := json.Unmarshal([]byte(c.ClientConfig), &cred); err != nil {
+			log.Printf("WARN: singbox sub parse cred for inbound %s: %v", c.InboundTag, err)
+			continue
+		}
+		serverName := cred.ServerName
+		if serverName == "" {
+			serverName = s.cfg.ServerHost
+		}
+		tag := strings.NewReplacer(" ", "-", "/", "-", "\\", "-").Replace(c.InboundTag)
+		ob := xray.Hysteria2OutboundSettings{
+			Type:       "hysteria2",
+			Tag:        fmt.Sprintf("%s-%d", tag, i),
+			Server:     s.cfg.ServerHost,
+			ServerPort: c.InboundPort,
+			Password:   cred.Password,
+			UpMbps:     cred.UpMbps,
+			DownMbps:   cred.DownMbps,
+			TLS: &xray.Hysteria2TLS{
+				Enabled:    true,
+				ServerName: serverName,
+			},
+		}
+		if cred.ObfsType != "" {
+			ob.Obfs = &xray.Hysteria2Obfs{
+				Type:     cred.ObfsType,
+				Password: cred.ObfsPassword,
+			}
+		}
+		outbounds = append(outbounds, ob)
+	}
+
+	if len(outbounds) == 0 {
+		jsonError(w, "no hysteria2 inbounds found", http.StatusNotFound)
+		return
+	}
+
+	cfg := buildSingboxClientConfig(outbounds)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Profile-Title", user.Username)
+	w.Header().Set("Content-Disposition", "attachment; filename=\"singbox.json\"")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(cfg)
+}
+
+// buildSingboxClientConfig assembles a minimal sing-box client config.
+func buildSingboxClientConfig(outbounds []xray.Hysteria2OutboundSettings) map[string]interface{} {
+	obs := make([]interface{}, 0, len(outbounds)+2)
+	for _, ob := range outbounds {
+		obs = append(obs, ob)
+	}
+	obs = append(obs,
+		map[string]string{"type": "direct", "tag": "direct"},
+		map[string]string{"type": "block", "tag": "block"},
+	)
+
+	return map[string]interface{}{
+		"log": map[string]interface{}{
+			"level":     "warn",
+			"timestamp": true,
+		},
+		"inbounds": []map[string]interface{}{
+			{
+				"type":        "mixed",
+				"tag":         "mixed-in",
+				"listen":      "127.0.0.1",
+				"listen_port": 2080,
+			},
+		},
+		"outbounds": obs,
+		"route": map[string]interface{}{
+			"auto_detect_interface": true,
+			"final":                 outbounds[0].Tag,
+		},
+	}
+}
+

--- a/internal/api/sub_singbox.go
+++ b/internal/api/sub_singbox.go
@@ -30,7 +30,8 @@ func (s *Server) handleSingboxSubscription(w http.ResponseWriter, r *http.Reques
 	}
 	clients, err := s.db.GetUserClients(user.ID)
 	if err != nil {
-		log.Printf("ERROR get user clients for singbox sub %s: %v", sanitizeLogField(user.Username), err) // #nosec G706 -- username is sanitized before logging.
+		// #nosec G706 -- username is sanitized before logging.
+		log.Printf("ERROR get user clients for singbox sub %s: %v", sanitizeLogField(user.Username), err)
 		jsonError(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/sub_singbox.go
+++ b/internal/api/sub_singbox.go
@@ -30,7 +30,7 @@ func (s *Server) handleSingboxSubscription(w http.ResponseWriter, r *http.Reques
 	}
 	clients, err := s.db.GetUserClients(user.ID)
 	if err != nil {
-		log.Printf("ERROR get user clients for singbox sub %s: %v", sanitizeLogField(user.Username), err)
+		log.Printf("ERROR get user clients for singbox sub %s: %v", sanitizeLogField(user.Username), err) // #nosec G706 -- username is sanitized before logging.
 		jsonError(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,16 @@ type Config struct {
 	// Generate both strings with: xray vlessenc
 	// Example: {"vless-reality-in": "mlkem768x25519plus.native.0rtt.(X25519 Password).(ML-KEM-768 Client)"}
 	VLESSClientEncryption map[string]string `json:"vless_client_encryption,omitempty"`
+	// SingboxConfig is an optional path to a sing-box server config file (e.g. /etc/sing-box/config.json).
+	// When set, Raven additionally parses sing-box inbounds (currently hysteria2) and syncs their users to DB.
+	// Xray config_dir sync is unaffected.
+	SingboxConfig string `json:"singbox_config,omitempty"`
+	// XrayEnabled controls whether Xray config_dir sync is active. Default true.
+	// Set to false when Xray is not installed — suppresses "directory not found" warnings.
+	XrayEnabled *bool `json:"xray_enabled,omitempty"`
+	// SingboxEnabled controls whether sing-box config sync is active. Default: true if singbox_config is set.
+	// Set to false to temporarily disable sing-box sync without removing singbox_config.
+	SingboxEnabled *bool `json:"singbox_enabled,omitempty"`
 
 	xrayFilePerm os.FileMode `json:"-"`
 }
@@ -144,6 +154,23 @@ func parseXrayConfigFileMode(s string) (os.FileMode, error) {
 	return os.FileMode(u) & 0o777, nil
 }
 
+// IsXrayEnabled returns true if Xray sync is enabled (default true).
+func (c *Config) IsXrayEnabled() bool {
+	if c.XrayEnabled == nil {
+		return true
+	}
+	return *c.XrayEnabled
+}
+
+// IsSingboxEnabled returns true if sing-box sync is enabled.
+// Defaults to true when singbox_config is set, false otherwise.
+func (c *Config) IsSingboxEnabled() bool {
+	if c.SingboxEnabled != nil {
+		return *c.SingboxEnabled
+	}
+	return strings.TrimSpace(c.SingboxConfig) != ""
+}
+
 // SubURL returns the full subscription URL for the given user token.
 func (c *Config) SubURL(token string) string {
 	return fmt.Sprintf("%s/sub/%s", c.BaseURL, token)
@@ -160,6 +187,8 @@ func (c *Config) SubURLs(token string) models.SubURLs {
 		Compact:     compact,
 		CompactText: compact + "/links.txt",
 		CompactB64:  compact + "/links.b64",
+		Singbox:     sub + "/singbox",
+		Hysteria2:   sub + "/hysteria2",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -146,6 +146,71 @@ func TestConfig_SubURL(t *testing.T) {
 	}
 }
 
+func TestConfig_IsXrayEnabled(t *testing.T) {
+	// nil pointer → default true
+	boolFalse := false
+	boolTrue := true
+	tests := []struct {
+		cfg  *Config
+		want bool
+	}{
+		{&Config{}, true},
+		{&Config{XrayEnabled: &boolTrue}, true},
+		{&Config{XrayEnabled: &boolFalse}, false},
+	}
+	for _, tt := range tests {
+		got := tt.cfg.IsXrayEnabled()
+		if got != tt.want {
+			t.Errorf("IsXrayEnabled: got %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestConfig_IsSingboxEnabled(t *testing.T) {
+	boolFalse := false
+	boolTrue := true
+	tests := []struct {
+		cfg  *Config
+		want bool
+	}{
+		{&Config{}, false},
+		{&Config{SingboxConfig: "/etc/sing-box/config.json"}, true},
+		{&Config{SingboxConfig: "  "}, false},
+		{&Config{SingboxEnabled: &boolTrue}, true},
+		{&Config{SingboxEnabled: &boolFalse, SingboxConfig: "/path"}, false},
+	}
+	for _, tt := range tests {
+		got := tt.cfg.IsSingboxEnabled()
+		if got != tt.want {
+			t.Errorf("IsSingboxEnabled(singbox_config=%q, enabled=%v): got %v, want %v",
+				tt.cfg.SingboxConfig, tt.cfg.SingboxEnabled, got, tt.want)
+		}
+	}
+}
+
+func TestConfig_SubURLs(t *testing.T) {
+	cfg := &Config{BaseURL: "https://vpn.example.com"}
+	urls := cfg.SubURLs("mytoken")
+	if urls.Full != "https://vpn.example.com/sub/mytoken" {
+		t.Errorf("Full: got %q", urls.Full)
+	}
+	if urls.LinksText != "https://vpn.example.com/sub/mytoken/links.txt" {
+		t.Errorf("LinksText: got %q", urls.LinksText)
+	}
+	if urls.LinksB64 != "https://vpn.example.com/sub/mytoken/links.b64" {
+		t.Errorf("LinksB64: got %q", urls.LinksB64)
+	}
+	if urls.Compact != "https://vpn.example.com/c/mytoken" {
+		t.Errorf("Compact: got %q", urls.Compact)
+	}
+	if urls.Singbox != "https://vpn.example.com/sub/mytoken/singbox" {
+		t.Errorf("Singbox: got %q", urls.Singbox)
+	}
+	if urls.Hysteria2 != "https://vpn.example.com/sub/mytoken/hysteria2" {
+		t.Errorf("Hysteria2: got %q", urls.Hysteria2)
+	}
+}
+
 func TestLoad_XrayConfigFileMode(t *testing.T) {
 	tests := []struct {
 		raw      string

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -79,6 +79,8 @@ type SubURLs struct {
 	Compact     string `json:"compact"`
 	CompactText string `json:"compact_txt"`
 	CompactB64  string `json:"compact_b64"`
+	Singbox     string `json:"singbox,omitempty"`
+	Hysteria2   string `json:"hysteria2,omitempty"`
 }
 
 // UserResponse is the API response body returned when a user is created or fetched.

--- a/internal/singbox/parser.go
+++ b/internal/singbox/parser.go
@@ -1,0 +1,154 @@
+// Package singbox provides parsing of sing-box server configuration files.
+package singbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// serverConfig is a minimal representation of a sing-box server config file.
+type serverConfig struct {
+	Inbounds []inbound `json:"inbounds"`
+}
+
+type inbound struct {
+	Type      string    `json:"type"`
+	Tag       string    `json:"tag"`
+	Listen    string    `json:"listen,omitempty"`
+	ListenPort int      `json:"listen_port,omitempty"`
+	Users     []user    `json:"users,omitempty"`
+	Obfs      *obfs     `json:"obfs,omitempty"`
+	TLS       *tls      `json:"tls,omitempty"`
+	UpMbps    int       `json:"up_mbps,omitempty"`
+	DownMbps  int       `json:"down_mbps,omitempty"`
+}
+
+type user struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+
+type obfs struct {
+	Type     string `json:"type,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type tls struct {
+	Enabled    bool   `json:"enabled,omitempty"`
+	ServerName string `json:"server_name,omitempty"`
+}
+
+// ParsedInbound is the result of parsing a single inbound from a sing-box config.
+type ParsedInbound struct {
+	Tag      string
+	Protocol string
+	Port     int
+	RawJSON  string
+	Clients  []ParsedClient
+}
+
+// ParsedClient is one user entry found in an inbound.
+type ParsedClient struct {
+	// Identity is the user name — used to match with existing DB users.
+	Identity   string
+	ConfigJSON string
+}
+
+// storedHysteria2Config holds per-user Hysteria2 credentials for the DB.
+type storedHysteria2Config struct {
+	Protocol string `json:"protocol"`
+	Password string `json:"password"`
+	// Transport settings shared across all users of the inbound.
+	ServerName  string `json:"server_name,omitempty"`
+	ObfsType    string `json:"obfs_type,omitempty"`
+	ObfsPassword string `json:"obfs_password,omitempty"`
+	UpMbps      int    `json:"up_mbps,omitempty"`
+	DownMbps    int    `json:"down_mbps,omitempty"`
+}
+
+// ParseConfig reads a sing-box config file and returns all supported inbounds.
+// Currently only hysteria2 inbounds are parsed.
+func ParseConfig(path string) ([]ParsedInbound, error) {
+	// #nosec G304 -- path comes from application config, not user input.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read sing-box config %s: %w", path, err)
+	}
+
+	var cfg serverConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse sing-box config %s: %w", path, err)
+	}
+
+	var result []ParsedInbound
+	for _, ib := range cfg.Inbounds {
+		switch ib.Type {
+		case "hysteria2":
+			parsed, err := parseHysteria2(ib, path)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: singbox parse hysteria2 inbound %q: %v\n", ib.Tag, err)
+				continue
+			}
+			result = append(result, *parsed)
+		}
+	}
+	return result, nil
+}
+
+func parseHysteria2(ib inbound, sourceFile string) (*ParsedInbound, error) {
+	tag := ib.Tag
+	if tag == "" {
+		tag = "hysteria2-in"
+	}
+
+	// Build shared transport metadata (same for all users of this inbound).
+	shared := storedHysteria2Config{
+		Protocol: "hysteria2",
+		UpMbps:   ib.UpMbps,
+		DownMbps: ib.DownMbps,
+	}
+	if ib.TLS != nil {
+		shared.ServerName = ib.TLS.ServerName
+	}
+	if ib.Obfs != nil {
+		shared.ObfsType = ib.Obfs.Type
+		shared.ObfsPassword = ib.Obfs.Password
+	}
+
+	// Raw JSON for DB storage — strip users to keep size small and avoid
+	// storing cleartext passwords in the inbound record.
+	rawIb := ib
+	rawIb.Users = nil
+	rawBytes, err := json.Marshal(rawIb)
+	if err != nil {
+		return nil, fmt.Errorf("marshal inbound raw: %w", err)
+	}
+
+	parsed := &ParsedInbound{
+		Tag:      tag,
+		Protocol: "hysteria2",
+		Port:     ib.ListenPort,
+		RawJSON:  string(rawBytes),
+	}
+
+	for _, u := range ib.Users {
+		if u.Name == "" {
+			continue
+		}
+		cred := shared
+		cred.Password = u.Password
+		credBytes, err := json.Marshal(cred)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: singbox marshal cred for user %q: %v\n", u.Name, err)
+			continue
+		}
+		parsed.Clients = append(parsed.Clients, ParsedClient{
+			Identity:   u.Name,
+			ConfigJSON: string(credBytes),
+		})
+	}
+
+	_ = sourceFile
+	return parsed, nil
+}

--- a/internal/singbox/parser.go
+++ b/internal/singbox/parser.go
@@ -138,7 +138,7 @@ func parseHysteria2(ib inbound, sourceFile string) (*ParsedInbound, error) {
 		}
 		cred := shared
 		cred.Password = u.Password
-		credBytes, err := json.Marshal(cred)
+		credBytes, err := json.Marshal(cred) // #nosec G117 -- marshaling user credential struct for storage, password field is intentional.
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WARN: singbox marshal cred for user %q: %v\n", u.Name, err)
 			continue

--- a/internal/singbox/parser.go
+++ b/internal/singbox/parser.go
@@ -138,7 +138,8 @@ func parseHysteria2(ib inbound, sourceFile string) (*ParsedInbound, error) {
 		}
 		cred := shared
 		cred.Password = u.Password
-		credBytes, err := json.Marshal(cred) // #nosec G117 -- marshaling user credential struct for storage, password field is intentional.
+		// #nosec G117 -- password-like fields are expected in stored protocol credentials.
+		credBytes, err := json.Marshal(cred)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WARN: singbox marshal cred for user %q: %v\n", u.Name, err)
 			continue

--- a/internal/singbox/parser_test.go
+++ b/internal/singbox/parser_test.go
@@ -1,0 +1,202 @@
+package singbox
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfig_Hysteria2(t *testing.T) {
+	cfg := `{
+		"inbounds": [
+			{
+				"type": "hysteria2",
+				"tag": "hy2-in",
+				"listen_port": 8443,
+				"up_mbps": 100,
+				"down_mbps": 100,
+				"users": [
+					{"name": "user1@test.com", "password": "pass1"},
+					{"name": "user2@test.com", "password": "pass2"}
+				],
+				"obfs": {"type": "salamander", "password": "obfspass"},
+				"tls": {"enabled": true, "server_name": "example.com"}
+			}
+		]
+	}`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inbounds, err := ParseConfig(path)
+	if err != nil {
+		t.Fatalf("ParseConfig error: %v", err)
+	}
+
+	if len(inbounds) != 1 {
+		t.Fatalf("expected 1 inbound, got %d", len(inbounds))
+	}
+
+	ib := inbounds[0]
+	if ib.Tag != "hy2-in" {
+		t.Errorf("tag: got %q, want %q", ib.Tag, "hy2-in")
+	}
+	if ib.Protocol != "hysteria2" {
+		t.Errorf("protocol: got %q, want %q", ib.Protocol, "hysteria2")
+	}
+	if ib.Port != 8443 {
+		t.Errorf("port: got %d, want 8443", ib.Port)
+	}
+	if len(ib.Clients) != 2 {
+		t.Fatalf("expected 2 clients, got %d", len(ib.Clients))
+	}
+
+	if ib.Clients[0].Identity != "user1@test.com" {
+		t.Errorf("client[0] identity: got %q", ib.Clients[0].Identity)
+	}
+
+	// Verify stored config JSON has correct fields
+	var cred storedHysteria2Config
+	if err := json.Unmarshal([]byte(ib.Clients[0].ConfigJSON), &cred); err != nil {
+		t.Fatalf("unmarshal cred: %v", err)
+	}
+	if cred.Password != "pass1" {
+		t.Errorf("password: got %q, want %q", cred.Password, "pass1")
+	}
+	if cred.ServerName != "example.com" {
+		t.Errorf("server_name: got %q, want %q", cred.ServerName, "example.com")
+	}
+	if cred.ObfsType != "salamander" {
+		t.Errorf("obfs_type: got %q, want %q", cred.ObfsType, "salamander")
+	}
+	if cred.ObfsPassword != "obfspass" {
+		t.Errorf("obfs_password: got %q", cred.ObfsPassword)
+	}
+	if cred.UpMbps != 100 {
+		t.Errorf("up_mbps: got %d, want 100", cred.UpMbps)
+	}
+
+	// Verify raw JSON doesn't contain user passwords
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(ib.RawJSON), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, ok := raw["users"]; ok {
+		t.Error("raw inbound JSON must not contain users (passwords)")
+	}
+}
+
+func TestParseConfig_SkipsUnknownInbounds(t *testing.T) {
+	cfg := `{
+		"inbounds": [
+			{"type": "vless", "tag": "vless-in", "listen_port": 443},
+			{"type": "hysteria2", "tag": "hy2-in", "listen_port": 8443,
+			 "users": [{"name": "u@test.com", "password": "p"}],
+			 "tls": {"enabled": true}}
+		]
+	}`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	inbounds, err := ParseConfig(path)
+	if err != nil {
+		t.Fatalf("ParseConfig error: %v", err)
+	}
+	if len(inbounds) != 1 {
+		t.Fatalf("expected 1 inbound (only hysteria2), got %d", len(inbounds))
+	}
+	if inbounds[0].Tag != "hy2-in" {
+		t.Errorf("expected hy2-in, got %q", inbounds[0].Tag)
+	}
+}
+
+func TestParseConfig_MissingFile(t *testing.T) {
+	_, err := ParseConfig("/nonexistent/config.json")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestParseConfig_NoObfs(t *testing.T) {
+	cfg := `{
+		"inbounds": [
+			{
+				"type": "hysteria2",
+				"tag": "hy2-plain",
+				"listen_port": 443,
+				"users": [{"name": "user@test.com", "password": "secret"}],
+				"tls": {"enabled": true, "server_name": "example.com"}
+			}
+		]
+	}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inbounds, err := ParseConfig(path)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(inbounds) != 1 || len(inbounds[0].Clients) != 1 {
+		t.Fatalf("expected 1 inbound with 1 client")
+	}
+	var cred storedHysteria2Config
+	if err := json.Unmarshal([]byte(inbounds[0].Clients[0].ConfigJSON), &cred); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cred.ObfsType != "" {
+		t.Errorf("expected empty ObfsType without obfs, got %q", cred.ObfsType)
+	}
+	if cred.ServerName != "example.com" {
+		t.Errorf("ServerName: got %q, want example.com", cred.ServerName)
+	}
+}
+
+func TestParseConfig_EmptyTag_DefaultsToHysteria2In(t *testing.T) {
+	cfg := `{
+		"inbounds": [
+			{
+				"type": "hysteria2",
+				"listen_port": 8443,
+				"users": [{"name": "u@test.com", "password": "p"}]
+			}
+		]
+	}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inbounds, err := ParseConfig(path)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if inbounds[0].Tag != "hysteria2-in" {
+		t.Errorf("tag: got %q, want hysteria2-in", inbounds[0].Tag)
+	}
+}
+
+func TestParseConfig_EmptyInbounds(t *testing.T) {
+	cfg := `{"inbounds": []}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inbounds, err := ParseConfig(path)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(inbounds) != 0 {
+		t.Errorf("expected 0 inbounds, got %d", len(inbounds))
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/alchemylink/raven-subscribe/internal/config"
 	"github.com/alchemylink/raven-subscribe/internal/database"
+	"github.com/alchemylink/raven-subscribe/internal/singbox"
 	"github.com/alchemylink/raven-subscribe/internal/xray"
 )
 
@@ -161,6 +162,25 @@ func (s *Syncer) Sync() error {
 		}
 	}
 
+	if s.cfg.IsXrayEnabled() {
+		if err := s.syncXray(); err != nil {
+			return err
+		}
+	} else {
+		log.Printf("Xray sync disabled (xray_enabled=false)")
+	}
+
+	if s.cfg.IsSingboxEnabled() {
+		if err := s.syncSingbox(strings.TrimSpace(s.cfg.SingboxConfig)); err != nil {
+			log.Printf("WARN: sing-box sync error: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// syncXray reads config_dir and upserts Xray inbounds/users into DB.
+func (s *Syncer) syncXray() error {
 	parsed, err := xray.ParseConfigDirWith(s.cfg.ConfigDir, s.cfg.VLESSClientEncryption)
 	if err != nil {
 		return fmt.Errorf("parse config dir: %w", err)
@@ -195,7 +215,6 @@ func (s *Syncer) Sync() error {
 			}
 			totalInbounds++
 
-			// Sync clients
 			for _, client := range ib.Clients {
 				if err := s.syncClient(ibID, client); err != nil {
 					log.Printf("WARN: sync client %s in %s: %v", client.Identity, ib.Tag, err)
@@ -234,7 +253,35 @@ func (s *Syncer) Sync() error {
 		}
 	}
 
-	log.Printf("Sync complete: %d inbounds, %d client entries", totalInbounds, totalClients)
+	log.Printf("Xray sync complete: %d inbounds, %d client entries", totalInbounds, totalClients)
+	return nil
+}
+
+// syncSingbox parses a sing-box config file and upserts its inbounds/users into DB.
+// Errors are non-fatal — Xray sync is unaffected.
+func (s *Syncer) syncSingbox(path string) error {
+	inbounds, err := singbox.ParseConfig(path)
+	if err != nil {
+		return err
+	}
+
+	for _, ib := range inbounds {
+		ibID, err := s.db.UpsertInbound(ib.Tag, ib.Protocol, ib.Port, path, ib.RawJSON)
+		if err != nil {
+			log.Printf("WARN: singbox upsert inbound %s: %v", ib.Tag, err)
+			continue
+		}
+		for _, client := range ib.Clients {
+			xrayClient := xray.ParsedClient{
+				Identity:   client.Identity,
+				ConfigJSON: client.ConfigJSON,
+			}
+			if err := s.syncClient(ibID, xrayClient); err != nil {
+				log.Printf("WARN: singbox sync client %s in %s: %v", client.Identity, ib.Tag, err)
+			}
+		}
+		log.Printf("sing-box sync: inbound %s (%s), %d users", ib.Tag, ib.Protocol, len(ib.Clients))
+	}
 	return nil
 }
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -126,6 +126,126 @@ func TestSyncer_Start_StopsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestSyncer_SyncSingbox(t *testing.T) {
+	dir := t.TempDir()
+	singboxCfg := `{
+		"inbounds": [
+			{
+				"type": "hysteria2",
+				"tag": "hy2-in",
+				"listen_port": 8443,
+				"users": [
+					{"name": "alice@test.com", "password": "passA"},
+					{"name": "bob@test.com", "password": "passB"}
+				],
+				"obfs": {"type": "salamander", "password": "obfssecret"},
+				"tls": {"enabled": true, "server_name": "example.com"}
+			}
+		]
+	}`
+	cfgPath := filepath.Join(dir, "singbox.json")
+	if err := os.WriteFile(cfgPath, []byte(singboxCfg), 0o600); err != nil {
+		t.Fatalf("write singbox config: %v", err)
+	}
+
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	cfg := &config.Config{SingboxConfig: cfgPath}
+	s := New(cfg, db)
+
+	if err := s.syncSingbox(cfgPath); err != nil {
+		t.Fatalf("syncSingbox: %v", err)
+	}
+
+	inbounds, err := db.ListInbounds()
+	if err != nil {
+		t.Fatalf("ListInbounds: %v", err)
+	}
+	if len(inbounds) != 1 {
+		t.Fatalf("expected 1 inbound, got %d", len(inbounds))
+	}
+	if inbounds[0].Tag != "hy2-in" {
+		t.Errorf("tag: got %q, want hy2-in", inbounds[0].Tag)
+	}
+
+	// Check users were created
+	users, err := db.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Errorf("expected 2 users, got %d", len(users))
+	}
+}
+
+func TestSyncer_Sync_SingboxEnabled(t *testing.T) {
+	dir := t.TempDir()
+	singboxCfg := `{
+		"inbounds": [
+			{
+				"type": "hysteria2",
+				"tag": "hy2-test",
+				"listen_port": 9443,
+				"users": [{"name": "user@test.com", "password": "p"}]
+			}
+		]
+	}`
+	cfgPath := filepath.Join(dir, "singbox.json")
+	if err := os.WriteFile(cfgPath, []byte(singboxCfg), 0o600); err != nil {
+		t.Fatalf("write singbox config: %v", err)
+	}
+
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	enabled := true
+	cfg := &config.Config{
+		ConfigDir:      dir,
+		SingboxConfig:  cfgPath,
+		SingboxEnabled: &enabled,
+	}
+	xrayDisabled := false
+	cfg.XrayEnabled = &xrayDisabled
+
+	s := New(cfg, db)
+	if err := s.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	inbounds, err := db.ListInbounds()
+	if err != nil {
+		t.Fatalf("ListInbounds: %v", err)
+	}
+	if len(inbounds) != 1 || inbounds[0].Tag != "hy2-test" {
+		t.Errorf("expected hy2-test inbound from singbox sync, got %v", inbounds)
+	}
+}
+
+func TestSyncer_SanitizeUsername(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"user@test.com", "user@test.com"},
+		{"  user  ", "user"},
+		{"user name", "user_name"},
+		{"user\tname", "user_name"},
+		{"user\nname", "username"},
+		{"user'name", "username"},
+		{`user"name`, "username"},
+		{"user;name", "username"},
+		{"user--name", "username"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := sanitizeUsername(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitizeUsername(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func testDB(t *testing.T) (*database.DB, func()) {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -336,7 +336,8 @@ func buildHysteria2Settings(host string, port int, tag string, cred StoredClient
 			Password: cred.ObfsPassword,
 		}
 	}
-	return json.Marshal(s) // #nosec G117 -- marshaling outbound settings struct, password field is intentional.
+	// #nosec G117 -- password-like fields are expected in stored protocol credentials.
+	return json.Marshal(s)
 }
 
 func buildSOCKSSettings(host string, port int, cred StoredClientConfig) (json.RawMessage, error) {

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -185,14 +185,17 @@ func buildOutbound(serverHost string, uc models.UserClientFull, index int) (*Out
 		return nil, fmt.Errorf("parse stored config: %w", err)
 	}
 
-	// Parse the server-side inbound raw JSON to get stream settings
-	var si ServerInbound
-	if err := json.Unmarshal([]byte(uc.InboundRaw), &si); err != nil {
-		return nil, fmt.Errorf("parse inbound raw: %w", err)
-	}
-
 	tag := fmt.Sprintf("%s-%d", sanitizeTag(uc.InboundTag), index)
 	proto := strings.ToLower(uc.InboundProtocol)
+
+	// Parse the server-side inbound raw JSON to get stream settings.
+	// Hysteria2 uses sing-box format — no Xray ServerInbound parsing needed.
+	var si ServerInbound
+	if proto != "hysteria2" {
+		if err := json.Unmarshal([]byte(uc.InboundRaw), &si); err != nil {
+			return nil, fmt.Errorf("parse inbound raw: %w", err)
+		}
+	}
 
 	var (
 		settings json.RawMessage
@@ -210,6 +213,8 @@ func buildOutbound(serverHost string, uc models.UserClientFull, index int) (*Out
 		settings, err = buildShadowsocksSettings(serverHost, uc.InboundPort, cred)
 	case "socks":
 		settings, err = buildSOCKSSettings(serverHost, uc.InboundPort, cred)
+	case "hysteria2":
+		settings, err = buildHysteria2Settings(serverHost, uc.InboundPort, tag, cred)
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %s", proto)
 	}
@@ -217,10 +222,13 @@ func buildOutbound(serverHost string, uc models.UserClientFull, index int) (*Out
 		return nil, err
 	}
 
-	// Convert server-side stream settings to client-side
-	clientStream, err := convertStreamSettings(si.StreamSettings, serverHost)
-	if err != nil {
-		return nil, fmt.Errorf("convert stream settings: %w", err)
+	// Hysteria2 uses sing-box format — no Xray stream settings.
+	var clientStream *StreamSettings
+	if proto != "hysteria2" {
+		clientStream, err = convertStreamSettings(si.StreamSettings, serverHost)
+		if err != nil {
+			return nil, fmt.Errorf("convert stream settings: %w", err)
+		}
 	}
 
 	ob := &Outbound{
@@ -300,6 +308,33 @@ func buildShadowsocksSettings(host string, port int, cred StoredClientConfig) (j
 			Method:   method,
 			Password: cred.Password,
 		}},
+	}
+	return json.Marshal(s)
+}
+
+func buildHysteria2Settings(host string, port int, tag string, cred StoredClientConfig) (json.RawMessage, error) {
+	serverName := cred.ServerName
+	if serverName == "" {
+		serverName = host
+	}
+	s := Hysteria2OutboundSettings{
+		Type:       "hysteria2",
+		Tag:        tag,
+		Server:     host,
+		ServerPort: port,
+		Password:   cred.Password,
+		UpMbps:     cred.UpMbps,
+		DownMbps:   cred.DownMbps,
+		TLS: &Hysteria2TLS{
+			Enabled:    true,
+			ServerName: serverName,
+		},
+	}
+	if cred.ObfsType != "" {
+		s.Obfs = &Hysteria2Obfs{
+			Type:     cred.ObfsType,
+			Password: cred.ObfsPassword,
+		}
 	}
 	return json.Marshal(s)
 }

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -336,7 +336,7 @@ func buildHysteria2Settings(host string, port int, tag string, cred StoredClient
 			Password: cred.ObfsPassword,
 		}
 	}
-	return json.Marshal(s)
+	return json.Marshal(s) // #nosec G117 -- marshaling outbound settings struct, password field is intentional.
 }
 
 func buildSOCKSSettings(host string, port int, cred StoredClientConfig) (json.RawMessage, error) {

--- a/internal/xray/parser.go
+++ b/internal/xray/parser.go
@@ -59,6 +59,10 @@ func ParseConfigDirWith(dir string, clientEncMap map[string]string) (map[string]
 func parseConfigDirWith(dir string, clientEncMap map[string]string) (map[string][]ParsedInbound, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// config_dir absent means Xray is not installed or not yet configured — not an error.
+			return make(map[string][]ParsedInbound), nil
+		}
 		return nil, fmt.Errorf("read dir %s: %w", dir, err)
 	}
 

--- a/internal/xray/types.go
+++ b/internal/xray/types.go
@@ -388,6 +388,31 @@ type RoutingRule struct {
 	Protocol    []string `json:"protocol,omitempty"`
 }
 
+// Hysteria2OutboundSettings holds Hysteria2 outbound server config for the client (sing-box format).
+type Hysteria2OutboundSettings struct {
+	Type       string        `json:"type"`
+	Tag        string        `json:"tag"`
+	Server     string        `json:"server"`
+	ServerPort int           `json:"server_port"`
+	Password   string        `json:"password"`
+	UpMbps     int           `json:"up_mbps,omitempty"`
+	DownMbps   int           `json:"down_mbps,omitempty"`
+	Obfs       *Hysteria2Obfs `json:"obfs,omitempty"`
+	TLS        *Hysteria2TLS `json:"tls,omitempty"`
+}
+
+// Hysteria2Obfs holds obfuscation settings for Hysteria2.
+type Hysteria2Obfs struct {
+	Type     string `json:"type"`
+	Password string `json:"password"`
+}
+
+// Hysteria2TLS holds TLS settings for Hysteria2 outbound.
+type Hysteria2TLS struct {
+	Enabled    bool   `json:"enabled"`
+	ServerName string `json:"server_name,omitempty"`
+}
+
 // StoredClientConfig holds per-user per-inbound credential data in DB
 type StoredClientConfig struct {
 	Protocol string `json:"protocol"`
@@ -406,6 +431,12 @@ type StoredClientConfig struct {
 	Method   string `json:"method,omitempty"`
 	// SOCKS
 	User string `json:"user,omitempty"`
+	// Hysteria2 transport metadata (shared across all users of one inbound).
+	ServerName   string `json:"server_name,omitempty"`
+	ObfsType     string `json:"obfs_type,omitempty"`
+	ObfsPassword string `json:"obfs_password,omitempty"`
+	UpMbps       int    `json:"up_mbps,omitempty"`
+	DownMbps     int    `json:"down_mbps,omitempty"`
 }
 
 // UnmarshalJSON keeps backward compatibility for VMess alterId naming.


### PR DESCRIPTION
## Summary

- Rewrite README.md and README.ru.md opening paragraph with explicit SEO keywords: `self-hosted`, `Xray-core`, `sing-box`, `VLESS`, `VMess`, `Trojan`, `Shadowsocks`, `Hysteria2`, `XHTTP/SplitHTTP`, `REALITY`, `V2RayNG`, `NekoBox`, `Hiddify`
- Add `docs/SEO_CHECKLIST.md` with ready-made texts for GitHub Topics, repo Description, and PR entries for awesome-selfhosted and awesome-v2ray

## Manual steps after merge

1. **GitHub Topics** — Settings → About → add: `xray xray-core vless vmess trojan shadowsocks hysteria2 subscription-server sing-box reality xhttp v2ray vpn proxy golang self-hosted`
2. **GitHub Description** — `Self-hosted subscription server for Xray-core and sing-box. Auto-discovers users, serves personal VPN config URLs for V2RayNG, NekoBox, Hiddify, Hysteria2.`
3. Submit PR to [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) and [awesome-v2ray](https://github.com/v2fly/awesome-v2ray) — texts in `docs/SEO_CHECKLIST.md`