### PR TITLE
docs: document sing-box/Hysteria2 generated config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,8 @@ When `singbox_config` is set, Raven parses the sing-box server config, discovers
 
 Xray sync and sing-box sync are fully independent — if one core is not installed, the other still works.
 
+**Important:** Hysteria2 users are excluded from Xray JSON subscriptions (`/sub/{token}`, `/c/{token}`). They are served exclusively via the dedicated Hysteria2 endpoints below.
+
 ### Configuration
 
 ```json
@@ -769,6 +771,37 @@ Xray sync and sing-box sync are fully independent — if one core is not install
 | `/sub/{token}/hysteria2` | `hysteria2://` share links | Hysteria2 app, Hiddify |
 | `/sub/{token}/hysteria2.b64` | Base64-encoded links | Clients that require encoded input |
 
+### Generated sing-box client config
+
+`/sub/{token}/singbox` returns a ready-to-use sing-box client config:
+
+```json
+{
+  "log": {"level": "warn", "timestamp": true},
+  "inbounds": [
+    {"type": "mixed", "tag": "mixed-in", "listen": "127.0.0.1", "listen_port": 2080}
+  ],
+  "outbounds": [
+    {
+      "type": "hysteria2",
+      "tag": "hysteria2-in-0",
+      "server": "vpn.example.com",
+      "server_port": 443,
+      "password": "<user-password>",
+      "tls": {"enabled": true, "server_name": "vpn.example.com"}
+    },
+    {"type": "direct", "tag": "direct"},
+    {"type": "block",  "tag": "block"}
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "final": "hysteria2-in-0"
+  }
+}
+```
+
+The `mixed` inbound listens on `127.0.0.1:2080` and accepts both SOCKS5 and HTTP proxy connections. All traffic is routed through the first Hysteria2 outbound by default.
+
 ### Salamander obfuscation
 
 If your sing-box inbound has `obfs` configured, Raven automatically includes it in all generated links and configs:
@@ -787,7 +820,7 @@ If your sing-box inbound has `obfs` configured, Raven automatically includes it 
 }
 ```
 
-The generated `hysteria2://` link will contain `?obfs=salamander&obfs-password=...` automatically.
+The generated `hysteria2://` share link will contain `?obfs=salamander&obfs-password=...` automatically, and the sing-box JSON config will include the `obfs` block in the outbound.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -739,6 +739,8 @@ Raven Subscribe может работать параллельно с [sing-box]
 
 Синхронизация Xray и sing-box полностью независимы — если одно ядро не установлено, второе продолжает работать.
 
+**Важно:** Hysteria2-пользователи исключаются из Xray JSON подписок (`/sub/{token}`, `/c/{token}`). Они отдаются исключительно через специальные Hysteria2-эндпоинты ниже.
+
 ### Конфигурация
 
 ```json
@@ -766,6 +768,37 @@ Raven Subscribe может работать параллельно с [sing-box]
 | `/sub/{token}/hysteria2` | `hysteria2://` share-ссылки | приложение Hysteria2, Hiddify |
 | `/sub/{token}/hysteria2.b64` | Base64-кодировка | клиенты, требующие Base64 |
 
+### Структура генерируемого sing-box конфига
+
+`/sub/{token}/singbox` возвращает готовый клиентский конфиг sing-box:
+
+```json
+{
+  "log": {"level": "warn", "timestamp": true},
+  "inbounds": [
+    {"type": "mixed", "tag": "mixed-in", "listen": "127.0.0.1", "listen_port": 2080}
+  ],
+  "outbounds": [
+    {
+      "type": "hysteria2",
+      "tag": "hysteria2-in-0",
+      "server": "vpn.example.com",
+      "server_port": 443,
+      "password": "<пароль-пользователя>",
+      "tls": {"enabled": true, "server_name": "vpn.example.com"}
+    },
+    {"type": "direct", "tag": "direct"},
+    {"type": "block",  "tag": "block"}
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "final": "hysteria2-in-0"
+  }
+}
+```
+
+`mixed` inbound слушает на `127.0.0.1:2080` и принимает подключения по SOCKS5 и HTTP proxy. Весь трафик по умолчанию направляется через первый Hysteria2 outbound.
+
 ### Обфускация Salamander
 
 Если в inbound sing-box настроен `obfs`, Raven автоматически включает его во все генерируемые ссылки и конфиги:
@@ -784,7 +817,7 @@ Raven Subscribe может работать параллельно с [sing-box]
 }
 ```
 
-Генерируемая `hysteria2://` ссылка автоматически будет содержать `?obfs=salamander&obfs-password=...`.
+Генерируемая `hysteria2://` ссылка автоматически будет содержать `?obfs=salamander&obfs-password=...`, а в sing-box JSON конфиг будет добавлен блок `obfs` в outbound.
 
 ---
 


### PR DESCRIPTION
Add:
- Note that Hysteria2 users are excluded from Xray JSON subscriptions
- Full example of generated sing-box client config (mixed inbound on 2080, hysteria2 outbound, direct/block, auto_detect_interface route)
- Note that obfs block is included in sing-box JSON when configured

## Description

<!-- What does this PR do? Why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behaviour change)
- [ ] CI / tooling
- [x] Documentation

## Pre-PR checklist

- [ ] `go test ./... -race -timeout 2m` passes locally
- [ ] `golangci-lint run` passes (or new suppressions are justified in comments)
- [ ] No secrets, real hostnames, or real tokens committed
- [ ] `docker/xray-subscription/config.json` contains only placeholder values

## Notes for reviewer

<!-- Anything that needs special attention, trade-offs, known limitations -->
