### PR TITLE
feat: add per-inbound host/port overrides for client config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,13 @@ xray-subscription -config /etc/xray-subscription/config.json
   "xray_api_addr": "",
   "xray_enabled": true,
   "singbox_config": "/etc/sing-box/config.json",
-  "singbox_enabled": true
+  "singbox_enabled": true,
+  "inbound_hosts": {
+    "vless-reality-in": "media.example.com"
+  },
+  "inbound_ports": {
+    "vless-reality-in": 8445
+  }
 }
 ```
 
@@ -298,6 +304,8 @@ Limits requests per IP per minute. `0` = disabled. Helps prevent abuse.
 | `xray_enabled` | `true` | Set to `false` to disable Xray config sync (suppress warnings if Xray is not installed). |
 | `singbox_config` | `""` | Path to sing-box server config file (e.g. `/etc/sing-box/config.json`). When set, Raven also syncs Hysteria2 inbounds from it. |
 | `singbox_enabled` | auto | Controls sing-box sync. Defaults to `true` when `singbox_config` is set. Set to `false` to temporarily disable without removing the path. |
+| `inbound_hosts` | `{}` | Per-inbound host overrides. Key: inbound tag, value: host/domain. Overrides `server_host` for matching inbounds in generated client configs. Falls back to `server_host` when tag is not listed. Example: `{"vless-reality-in": "relay.example.com"}` |
+| `inbound_ports` | `{}` | Per-inbound port overrides. Key: inbound tag, value: port number. Overrides the inbound's own port in generated client configs. Useful when clients connect through a relay that listens on a different port. Example: `{"vless-reality-in": 8445}` |
 
 **DB ↔ Xray sync (when `api_user_inbound_tag` is set):** The database is the source of truth. All changes propagate to Xray immediately:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -233,7 +233,13 @@ xray-subscription -config /etc/xray-subscription/config.json
   "xray_api_addr": "",
   "xray_enabled": true,
   "singbox_config": "/etc/sing-box/config.json",
-  "singbox_enabled": true
+  "singbox_enabled": true,
+  "inbound_hosts": {
+    "vless-reality-in": "media.example.com"
+  },
+  "inbound_ports": {
+    "vless-reality-in": 8445
+  }
 }
 ```
 
@@ -295,6 +301,8 @@ xray-subscription -config /etc/xray-subscription/config.json
 | `xray_enabled` | `true` | Установите `false` для отключения синхронизации Xray (убирает предупреждения, если Xray не установлен). |
 | `singbox_config` | `""` | Путь к серверному конфигу sing-box (например `/etc/sing-box/config.json`). При наличии Raven также синхронизирует Hysteria2 inbound-ы. |
 | `singbox_enabled` | авто | Управляет синхронизацией sing-box. По умолчанию `true`, если задан `singbox_config`. Установите `false` для временного отключения без удаления пути. |
+| `inbound_hosts` | `{}` | Переопределение хоста для конкретных inbound-ов. Ключ: тег inbound, значение: хост/домен. Переопределяет `server_host` для подходящих inbound-ов в генерируемых клиентских конфигах. При отсутствии тега используется `server_host`. Пример: `{"vless-reality-in": "relay.example.com"}` |
+| `inbound_ports` | `{}` | Переопределение порта для конкретных inbound-ов. Ключ: тег inbound, значение: порт. Переопределяет собственный порт inbound в генерируемых конфигах. Полезно, когда клиенты подключаются через relay на другом порту. Пример: `{"vless-reality-in": 8445}` |
 
 **Синхронизация БД ↔ Xray** (при заданном `api_user_inbound_tag`): База данных — источник правды. Все изменения сразу отражаются в Xray:
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -237,6 +237,8 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 
 	cfg, err := xray.GenerateClientConfig(
 		s.cfg.ServerHost,
+		s.cfg.InboundHosts,
+		s.cfg.InboundPorts,
 		*user,
 		clients,
 		globalRoutesJSON,

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -314,6 +314,8 @@ func (s *Server) generateConfigForSubscriptionRequestWithForcedProtocol(r *http.
 	}
 	cfg, err := xray.GenerateClientConfig(
 		s.cfg.ServerHost,
+		s.cfg.InboundHosts,
+		s.cfg.InboundPorts,
 		*user,
 		clients,
 		globalRoutesJSON,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,17 @@ type Config struct {
 	APIUserInboundPort int `json:"api_user_inbound_port,omitempty"`
 	// Octal permission bits for Xray JSON files Raven writes under config_dir (e.g. "0644", "0755"). Empty = 0600.
 	XrayConfigFileMode string `json:"xray_config_file_mode,omitempty"`
+	// InboundHosts overrides server_host for specific inbound tags.
+	// Key: inbound tag, value: host/IP to use in generated client configs.
+	// Falls back to ServerHost when a tag is not listed.
+	// Example: {"hysteria-in": "64.226.79.239", "vless-reality-in": "zirgate.com"}
+	InboundHosts map[string]string `json:"inbound_hosts,omitempty"`
+
+	// InboundPorts overrides the port for specific inbound tags in generated client configs.
+	// Key: inbound tag, value: port number. Falls back to inbound's own port when tag is not listed.
+	// Example: {"vless-reality-in": 8444} — clients connect to relay:8444 instead of EU:443
+	InboundPorts map[string]int `json:"inbound_ports,omitempty"`
+
 	// VLESSClientEncryption maps VLESS inbound tag to its client-side VLESS Encryption string.
 	// Required when the inbound uses VLESS Encryption (decryption != "none").
 	// Generate both strings with: xray vlessenc
@@ -169,6 +180,15 @@ func (c *Config) IsSingboxEnabled() bool {
 		return *c.SingboxEnabled
 	}
 	return strings.TrimSpace(c.SingboxConfig) != ""
+}
+
+// HostForInbound returns the server host for a given inbound tag.
+// Falls back to ServerHost if the tag is not in InboundHosts.
+func (c *Config) HostForInbound(tag string) string {
+	if h, ok := c.InboundHosts[tag]; ok && strings.TrimSpace(h) != "" {
+		return h
+	}
+	return c.ServerHost
 }
 
 // SubURL returns the full subscription URL for the given user token.

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -15,7 +15,9 @@ import (
 
 // GenerateClientConfig produces a complete xray client JSON config for a user.
 // socksPort and httpPort are the local proxy ports in the generated config; 0 = use default (2080, 1081).
-func GenerateClientConfig(serverHost string, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string, socksPort, httpPort int) (*ClientConfig, error) {
+// inboundHosts overrides serverHost per inbound tag; falls back to serverHost when tag is not listed.
+// inboundPorts overrides the port per inbound tag; falls back to the inbound's own port when tag is not listed.
+func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inboundPorts map[string]int, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string, socksPort, httpPort int) (*ClientConfig, error) {
 	if socksPort <= 0 {
 		socksPort = 2080
 	}
@@ -38,7 +40,14 @@ func GenerateClientConfig(serverHost string, user models.User, clients []models.
 	// Build outbounds from each user client
 	var proxyTags []string
 	for i, uc := range clients {
-		ob, err := buildOutbound(serverHost, uc, i)
+		host := serverHost
+		if h, ok := inboundHosts[uc.InboundTag]; ok && strings.TrimSpace(h) != "" {
+			host = h
+		}
+		if p, ok := inboundPorts[uc.InboundTag]; ok && p > 0 {
+			uc.InboundPort = p
+		}
+		ob, err := buildOutbound(host, uc, i)
 		if err != nil {
 			log.Printf("WARN: build outbound for inbound %s: %v", uc.InboundTag, err)
 			continue

--- a/internal/xray/generator_test.go
+++ b/internal/xray/generator_test.go
@@ -22,7 +22,7 @@ func TestGenerateClientConfig(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestGenerateClientConfigCustomInboundPorts(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 31080, 31081)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 31080, 31081)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestGenerateClientConfigMultiProxy(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "leastPing", "https://www.gstatic.com/generate_204", "30s", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "leastPing", "https://www.gstatic.com/generate_204", "30s", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestGenerateClientConfigSingleProxy(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestGenerateClientConfigInvalidClientConfig(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err == nil {
 		t.Fatal("expected error for invalid client config, got nil")
 	}
@@ -210,7 +210,7 @@ func TestGenerateClientConfigInvalidInboundRaw(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err == nil {
 		t.Fatal("expected error for invalid inbound raw, got nil")
 	}
@@ -231,7 +231,7 @@ func TestGenerateClientConfigNoValidOutbounds(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err == nil {
 		t.Fatal("expected error for no valid outbounds, got nil")
 	}
@@ -257,7 +257,7 @@ func TestGenerateClientConfigWithGlobalRoutes(t *testing.T) {
 
 	globalRoutes := `[{"type":"field","outboundTag":"direct","domain":["geosite:ru"]}]`
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, globalRoutes, "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, globalRoutes, "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestGenerateClientConfigUserRoutes(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestGenerateClientConfigMuxEnabled(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestGenerateClientConfigNoMuxForREALITY(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestGenerateClientConfigShadowsocks(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestGenerateClientConfigTrojan(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestGenerateClientConfigSOCKS(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestGenerateClientConfigMarshalJSON(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestGenerateClientConfigPortParsing(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Allows routing different VLESS inbounds through different hosts and ports in generated client configs. This enables a unified `media.zirgate.com` endpoint for all VLESS protocols via a relay architecture.

**New config fields:**
- `inbound_hosts` — overrides `server_host` per inbound tag (fallback to `server_host` when tag not listed)
- `inbound_ports` — overrides the port per inbound tag (fallback to inbound's own port when tag not listed)

**Example `config.json`:**
```json
{
  "server_host": "media.zirgate.com",
  "inbound_hosts": {
    "vless-reality-in": "media.zirgate.com",
    "vless-xhttp-in": "media.zirgate.com"
  },
  "inbound_ports": {
    "vless-reality-in": 8445
  }
}
```

This generates client configs where Reality connects to `media.zirgate.com:8445` (nginx stream relay → Xray:443) while XHTTP uses `media.zirgate.com:2053`.

## Changes

- `internal/config/config.go`: add `InboundHosts`, `InboundPorts` fields and `HostForInbound()` helper
- `internal/xray/generator.go`: `GenerateClientConfig()` accepts `inboundHosts`/`inboundPorts`, applies overrides per client
- `internal/api/server.go`, `sub_links.go`: pass `cfg.InboundHosts`, `cfg.InboundPorts` to generator
- `internal/xray/generator_test.go`: update all call sites (`nil, nil` for no overrides)

## Test plan

- [ ] `go test ./...` passes
- [ ] Subscription with `inbound_hosts`/`inbound_ports` set returns correct addresses and ports per inbound
- [ ] Subscription without these fields set behaves as before (fallback to `server_host` and inbound's port)