### PR TITLE
feat: per-inbound host/port overrides, VLESS Encryption, security hardening

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Scan
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, develop]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, master, proj-check-*]
+    branches: [main, master, develop, proj-check-*]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -155,9 +155,6 @@ func (s *Server) adminAuth(next http.Handler) http.Handler {
 			return
 		}
 		token := r.Header.Get("X-Admin-Token")
-		if token == "" {
-			token = r.URL.Query().Get("admin_token")
-		}
 		if subtle.ConstantTimeCompare([]byte(token), []byte(s.cfg.AdminToken)) != 1 {
 			jsonError(w, "unauthorized", http.StatusUnauthorized)
 			return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,8 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config file: %w", err)
 	}
 
+	normalizeVLESSClientEncryption(cfg)
+
 	if cfg.ServerHost == "" {
 		return nil, fmt.Errorf("server_host is required in config")
 	}
@@ -116,6 +118,28 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("xray_config_file_mode: %w", err)
 	}
 	return cfg, nil
+}
+
+// normalizeVLESSClientEncryption trims map keys and values so lookups match Xray inbound tags
+// (avoids misses from accidental spaces in config.json).
+func normalizeVLESSClientEncryption(cfg *Config) {
+	if cfg == nil || len(cfg.VLESSClientEncryption) == 0 {
+		return
+	}
+	out := make(map[string]string, len(cfg.VLESSClientEncryption))
+	for k, v := range cfg.VLESSClientEncryption {
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		cfg.VLESSClientEncryption = nil
+	} else {
+		cfg.VLESSClientEncryption = out
+	}
 }
 
 // XrayConfigFilePerm returns permission bits used when writing Xray JSON configs under config_dir.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -254,3 +254,31 @@ func TestLoad_XrayConfigFileMode(t *testing.T) {
 		}
 	}
 }
+
+func TestLoad_VLESSClientEncryption_TrimsKeysAndValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	json := `{
+		"server_host": "vpn.example.com",
+		"admin_token": "x",
+		"vless_client_encryption": {
+			"  vless-reality-in  ": "  client-string-here  ",
+			"bad": "   ",
+			"  ": "skipped"
+		}
+	}`
+	if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, ok := cfg.VLESSClientEncryption["vless-reality-in"]
+	if !ok || got != "client-string-here" {
+		t.Fatalf("VLESSClientEncryption: got %q ok=%v, want client-string-here", got, ok)
+	}
+	if len(cfg.VLESSClientEncryption) != 1 {
+		t.Errorf("expected 1 map entry after normalize, got %d", len(cfg.VLESSClientEncryption))
+	}
+}

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -247,8 +247,8 @@ func buildOutbound(serverHost string, uc models.UserClientFull, index int) (*Out
 		StreamSettings: clientStream,
 	}
 
-	// Enable Mux for compatible protocols (not XTLS/REALITY)
-	if shouldUseMux(proto, cred.Flow, clientStream) {
+	// Enable Mux for compatible protocols (not XTLS/REALITY / VLESS Encryption)
+	if shouldUseMux(proto, cred.Flow, cred.Encryption, clientStream) {
 		ob.Mux = &MuxConfig{Enabled: true, Concurrency: 8}
 	}
 
@@ -535,9 +535,13 @@ func derivePublicKey(privateKeyB64 string) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(pubBytes), nil
 }
 
-func shouldUseMux(proto, flow string, ss *StreamSettings) bool {
+func shouldUseMux(proto, flow, encryption string, ss *StreamSettings) bool {
 	// xtls-rprx-vision is fundamentally incompatible with Mux regardless of security layer
 	if flow == "xtls-rprx-vision" {
+		return false
+	}
+	// VLESS Encryption (outbound encryption != none) must not use Mux
+	if strings.TrimSpace(encryption) != "" && strings.TrimSpace(encryption) != "none" {
 		return false
 	}
 	if proto == "vless" || proto == "trojan" {

--- a/internal/xray/parser.go
+++ b/internal/xray/parser.go
@@ -46,17 +46,19 @@ func GetInboundByTag(dir, tag string) (*ParsedInbound, string, error) {
 
 // ParseConfigDir reads all JSON files from dir and returns parsed inbounds per file.
 // Client VLESS Encryption strings are not resolved; use ParseConfigDirWith for that.
+// Does not WARN when VLESS Encryption is enabled but no client map is supplied (internal use).
 func ParseConfigDir(dir string) (map[string][]ParsedInbound, error) {
-	return parseConfigDirWith(dir, nil)
+	return parseConfigDirWith(dir, nil, false)
 }
 
 // ParseConfigDirWith is like ParseConfigDir but resolves VLESS Encryption client strings.
 // clientEncMap maps inbound tag to the client-side VLESS Encryption string from config.
+// When a tag needs a client string but it is missing from the map (or map is nil), logs WARN.
 func ParseConfigDirWith(dir string, clientEncMap map[string]string) (map[string][]ParsedInbound, error) {
-	return parseConfigDirWith(dir, clientEncMap)
+	return parseConfigDirWith(dir, clientEncMap, true)
 }
 
-func parseConfigDirWith(dir string, clientEncMap map[string]string) (map[string][]ParsedInbound, error) {
+func parseConfigDirWith(dir string, clientEncMap map[string]string, warnVLESSClientEnc bool) (map[string][]ParsedInbound, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -67,6 +69,8 @@ func parseConfigDirWith(dir string, clientEncMap map[string]string) (map[string]
 	}
 
 	result := make(map[string][]ParsedInbound)
+	// One WARN per inbound tag per directory scan (same tag may appear in multiple JSON files).
+	vlessEncWarned := make(map[string]struct{})
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -76,7 +80,7 @@ func parseConfigDirWith(dir string, clientEncMap map[string]string) (map[string]
 			continue
 		}
 		fullPath := filepath.Join(dir, name)
-		inbounds, err := parseConfigFileWith(fullPath, clientEncMap)
+		inbounds, err := parseConfigFileWith(fullPath, clientEncMap, vlessEncWarned, warnVLESSClientEnc)
 		if err != nil {
 			// Log and continue; don't fail all due to one bad file
 			fmt.Fprintf(os.Stderr, "WARN: parse %s: %v\n", fullPath, err)
@@ -89,10 +93,12 @@ func parseConfigDirWith(dir string, clientEncMap map[string]string) (map[string]
 
 // ParseConfigFile parses a single xray server config JSON file.
 func ParseConfigFile(path string) ([]ParsedInbound, error) {
-	return parseConfigFileWith(path, nil)
+	return parseConfigFileWith(path, nil, nil, false)
 }
 
-func parseConfigFileWith(path string, clientEncMap map[string]string) ([]ParsedInbound, error) {
+// vlessEncWarned, when non-nil, suppresses duplicate VLESS Encryption WARN lines for the same inbound tag
+// across multiple files in one directory scan. nil = warn every time (single-file parse).
+func parseConfigFileWith(path string, clientEncMap map[string]string, vlessEncWarned map[string]struct{}, warnVLESSClientEnc bool) ([]ParsedInbound, error) {
 	// #nosec G304 -- path comes from configured xray config directory traversal.
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -125,7 +131,7 @@ func parseConfigFileWith(path string, clientEncMap map[string]string) ([]ParsedI
 			continue
 		}
 
-		clients, err := extractClients(si, clientEncMap)
+		clients, err := extractClients(si, clientEncMap, vlessEncWarned, warnVLESSClientEnc)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WARN: extract clients for %s: %v\n", si.Tag, err)
 		}
@@ -162,13 +168,15 @@ func parsePort(raw json.RawMessage) (int, error) {
 
 // extractClients pulls all client credentials from an inbound.
 // clientEncMap maps inbound tag to the client-side VLESS Encryption string (may be nil).
-func extractClients(si ServerInbound, clientEncMap map[string]string) ([]ParsedClient, error) {
+// vlessEncWarned deduplicates VLESS Encryption warnings when scanning a directory; nil = no dedup.
+// warnVLESSClientEnc: when false, missing vless_client_encryption is not logged (ParseConfigDir / single-file tools).
+func extractClients(si ServerInbound, clientEncMap map[string]string, vlessEncWarned map[string]struct{}, warnVLESSClientEnc bool) ([]ParsedClient, error) {
 	proto := strings.ToLower(si.Protocol)
 	switch proto {
 	case "vmess":
 		return extractVMess(si)
 	case "vless":
-		return extractVLESS(si, clientEncMap)
+		return extractVLESS(si, clientEncMap, vlessEncWarned, warnVLESSClientEnc)
 	case "trojan":
 		return extractTrojan(si)
 	case "shadowsocks":
@@ -200,24 +208,35 @@ func extractVMess(si ServerInbound) ([]ParsedClient, error) {
 	return clients, nil
 }
 
-func extractVLESS(si ServerInbound, clientEncMap map[string]string) ([]ParsedClient, error) {
+func extractVLESS(si ServerInbound, clientEncMap map[string]string, vlessEncWarned map[string]struct{}, warnVLESSClientEnc bool) ([]ParsedClient, error) {
 	var s VLESSInboundSettings
 	if err := json.Unmarshal(si.Settings, &s); err != nil {
 		return nil, err
 	}
+
+	inboundTag := strings.TrimSpace(si.Tag)
 
 	// Determine client-side encryption string.
 	// The server's settings.decryption contains private keys and is NOT sent to clients.
 	// The client encryption string (public keys only) comes from vless_client_encryption config map.
 	clientEnc := "none"
 	if s.Decryption != "" && s.Decryption != "none" {
-		if enc, ok := clientEncMap[si.Tag]; ok && enc != "" {
+		if enc, ok := clientEncMap[inboundTag]; ok && enc != "" {
 			clientEnc = enc
-		} else {
-			fmt.Fprintf(os.Stderr,
-				"WARN: inbound %q uses VLESS Encryption but vless_client_encryption[%q] is not set; "+
-					"client outbound encryption will be \"none\" — clients will fail to connect\n",
-				si.Tag, si.Tag)
+		} else if warnVLESSClientEnc {
+			doWarn := vlessEncWarned == nil
+			if !doWarn {
+				if _, dup := vlessEncWarned[inboundTag]; !dup {
+					vlessEncWarned[inboundTag] = struct{}{}
+					doWarn = true
+				}
+			}
+			if doWarn {
+				fmt.Fprintf(os.Stderr,
+					"WARN: inbound %q uses VLESS Encryption but vless_client_encryption[%q] is not set; "+
+						"client outbound encryption will be \"none\" — clients will fail to connect\n",
+					inboundTag, inboundTag)
+			}
 		}
 	}
 

--- a/internal/xray/parser_test.go
+++ b/internal/xray/parser_test.go
@@ -2,6 +2,7 @@ package xray
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -330,6 +331,50 @@ func TestFirstNonEmpty(t *testing.T) {
 				t.Fatalf("firstNonEmpty(%v) = %v, want %v", tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+// Two JSON files in config.d often repeat the same inbound; VLESS Encryption WARN must not spam once per file.
+func TestParseConfigDirWith_DedupVLESSEncryptionWarn(t *testing.T) {
+	dir := t.TempDir()
+	fragment := `{
+		"inbounds": [{
+			"tag": "dup-vless-in",
+			"port": 443,
+			"protocol": "vless",
+			"settings": {
+				"decryption": "mlkem768x25519.native",
+				"clients": [{"id": "11111111-1111-1111-1111-111111111111", "email": "a@test.com"}]
+			}
+		}]
+	}`
+	for _, name := range []string{"01.json", "02.json"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fragment), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldErr := os.Stderr
+	os.Stderr = w
+	_, parseErr := ParseConfigDirWith(dir, nil)
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = oldErr
+	if parseErr != nil {
+		t.Fatalf("ParseConfigDirWith: %v", parseErr)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Close()
+	n := strings.Count(string(out), `vless_client_encryption["dup-vless-in"]`)
+	if n != 1 {
+		t.Fatalf("expected 1 deduplicated VLESS enc WARN, got %d\n%s", n, out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Per-inbound host/port overrides for client config generation (`inbound_hosts`, `inbound_ports`) — allows routing different protocols through different addresses in client configs
- VLESS Encryption: `mlkem768x25519plus` handling in config parsing and generation (Xray-core >= 26.x)
- Security: removed `admin_token` from URL query param — header-only auth (`X-Admin-Token`)
- CI: run tests on `develop` branch and PRs targeting `develop`
- docs: per-inbound host/port fields documented in README

## Test plan
- [x] CI passing: Test, Security Scan
- [x] Raven-subscribe starts and responds on `/health`
- [x] Subscription generated with correct host/port per inbound
- [x] VLESS Encryption config parses correctly