### PR TITLE
Add fallback subscription token + DNSServer type with skipFallback/expectIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,12 @@ xray-subscription -config /etc/xray-subscription/config.json
   },
   "inbound_ports": {
     "vless-reality-in": 8445
-  }
+  },
+  "client_dns_servers": [
+    "1.1.1.1",
+    "8.8.8.8",
+    { "address": "77.88.8.8", "domains": ["geosite:yandex"] }
+  ]
 }
 ```
 
@@ -287,6 +292,7 @@ Used when your Xray config has multiple outbounds (e.g. several proxy nodes). Co
 |-------|---------|-------------|
 | `socks_inbound_port` | `2080` | Local SOCKS5 proxy port in generated client configs. Clients use this for system/app proxy. |
 | `http_inbound_port` | `1081` | Local HTTP proxy port in generated client configs. |
+| `client_dns_servers` | `["1.1.1.1","8.8.8.8","8.8.4.4"]` | DNS server list injected into generated client configs. Each entry is either a plain IP string or an object with `address` and `domains` fields (Xray DNS format). When omitted or empty, uses the built-in default. Example with per-domain resolver: `["1.1.1.1", {"address": "77.88.8.8", "domains": ["geosite:yandex"]}]`. |
 
 #### Rate limiting
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -240,7 +240,12 @@ xray-subscription -config /etc/xray-subscription/config.json
   },
   "inbound_ports": {
     "vless-reality-in": 8445
-  }
+  },
+  "client_dns_servers": [
+    "1.1.1.1",
+    "8.8.8.8",
+    { "address": "77.88.8.8", "domains": ["geosite:yandex"] }
+  ]
 }
 ```
 
@@ -284,6 +289,7 @@ xray-subscription -config /etc/xray-subscription/config.json
 |------|--------------|----------|
 | `socks_inbound_port` | `2080` | Порт локального SOCKS5-прокси в генерируемых конфигах. Используется клиентами для системного/прикладного прокси. |
 | `http_inbound_port` | `1081` | Порт локального HTTP-прокси в генерируемых конфигах. |
+| `client_dns_servers` | `["1.1.1.1","8.8.8.8","8.8.4.4"]` | Список DNS-серверов, подставляемых в генерируемые клиентские конфиги. Каждый элемент — строка с IP или объект с полями `address` и `domains` (формат DNS Xray). При пустом значении или отсутствии поля используется встроенный дефолт. Пример с domain-специфичным резолвером: `["1.1.1.1", {"address": "77.88.8.8", "domains": ["geosite:yandex"]}]`. |
 
 #### Ограничение частоты запросов
 

--- a/internal/api/fallback.go
+++ b/internal/api/fallback.go
@@ -42,7 +42,7 @@ func (s *Server) handleFallbackSubscription(w http.ResponseWriter, r *http.Reque
 
 	go func() {
 		if err := s.db.SetFallbackAccessedAt(user.ID, time.Now().UTC()); err != nil {
-			log.Printf("WARN set fallback_accessed_at for user %d: %v", user.ID, err) //nolint:noctx // #nosec G706 -- user.ID is int, err is a db error
+			log.Printf("WARN set fallback_accessed_at for user %d: %v", user.ID, err) // #nosec G706 -- user.ID is int, err is internal db error
 		}
 	}()
 

--- a/internal/api/fallback.go
+++ b/internal/api/fallback.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"log"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// handleFallbackSubscription serves /sub/fallback/{fallback_token}.
+// Returns the same content as the primary subscription endpoint but keyed on the fallback token.
+// Records the access time. Returns 404 when fallback is globally disabled or token is unknown.
+func (s *Server) handleFallbackSubscription(w http.ResponseWriter, r *http.Request) {
+	fallbackToken := mux.Vars(r)["token"]
+	if fallbackToken == "" {
+		jsonError(w, "missing token", http.StatusBadRequest)
+		return
+	}
+
+	enabled, err := s.db.GetFallbackEnabled()
+	if err != nil {
+		log.Printf("ERROR get fallback enabled: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if !enabled {
+		jsonError(w, "fallback subscription disabled", http.StatusForbidden)
+		return
+	}
+
+	user, err := s.db.GetUserByFallbackToken(fallbackToken)
+	if err != nil || user == nil {
+		jsonError(w, "invalid token", http.StatusNotFound)
+		return
+	}
+	if !user.Enabled {
+		jsonError(w, "user disabled", http.StatusForbidden)
+		return
+	}
+
+	go func() {
+		if err := s.db.SetFallbackAccessedAt(user.ID, time.Now().UTC()); err != nil {
+			log.Printf("WARN set fallback_accessed_at for user %d: %v", user.ID, err)
+		}
+	}()
+
+	w.Header().Set("X-Fallback-Token", "true")
+
+	// Delegate to the primary subscription handler using the user's primary token.
+	// Swap the {token} path variable so handleSubscription resolves the user correctly.
+	r = mux.SetURLVars(r, map[string]string{"token": user.Token})
+	s.handleSubscription(w, r)
+}
+
+// regenerateFallbackToken generates a new fallback token for the user.
+// POST /api/users/{id}/fallback/token
+func (s *Server) regenerateFallbackToken(w http.ResponseWriter, r *http.Request) {
+	user, err := s.getByID(w, r)
+	if user == nil || err != nil {
+		return
+	}
+	newToken := generateToken()
+	if err := s.db.UpdateFallbackToken(user.ID, newToken); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]string{
+		"fallback_token": newToken,
+		"fallback_url":   s.cfg.FallbackURL(newToken),
+	})
+}
+
+// getFallbackStatus returns the global fallback enabled/disabled state.
+// GET /api/fallback/status
+func (s *Server) getFallbackStatus(w http.ResponseWriter, _ *http.Request) {
+	enabled, err := s.db.GetFallbackEnabled()
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]bool{"enabled": enabled})
+}
+
+// enableFallback enables the global fallback subscription endpoint.
+// POST /api/fallback/enable
+func (s *Server) enableFallback(w http.ResponseWriter, _ *http.Request) {
+	if err := s.db.SetFallbackEnabled(true); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]bool{"enabled": true})
+}
+
+// disableFallback disables the global fallback subscription endpoint.
+// POST /api/fallback/disable
+func (s *Server) disableFallback(w http.ResponseWriter, _ *http.Request) {
+	if err := s.db.SetFallbackEnabled(false); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]bool{"enabled": false})
+}
+
+// listFallbackAccessedUsers returns all users who have accessed their fallback subscription,
+// ordered by most recent access. GET /api/fallback/accessed
+func (s *Server) listFallbackAccessedUsers(w http.ResponseWriter, _ *http.Request) {
+	users, err := s.db.ListUsers()
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	type entry struct {
+		ID                 int64      `json:"id"`
+		Username           string     `json:"username"`
+		FallbackToken      string     `json:"fallback_token,omitempty"`
+		FallbackAccessedAt *time.Time `json:"fallback_accessed_at"`
+		FallbackURL        string     `json:"fallback_url,omitempty"`
+	}
+	var result []entry
+	for _, u := range users {
+		if u.FallbackAccessedAt == nil {
+			continue
+		}
+		result = append(result, entry{
+			ID:                 u.ID,
+			Username:           u.Username,
+			FallbackToken:      u.FallbackToken,
+			FallbackAccessedAt: u.FallbackAccessedAt,
+			FallbackURL:        s.cfg.FallbackURL(u.FallbackToken),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].FallbackAccessedAt.After(*result[j].FallbackAccessedAt)
+	})
+	jsonOK(w, result)
+}

--- a/internal/api/fallback.go
+++ b/internal/api/fallback.go
@@ -42,7 +42,7 @@ func (s *Server) handleFallbackSubscription(w http.ResponseWriter, r *http.Reque
 
 	go func() {
 		if err := s.db.SetFallbackAccessedAt(user.ID, time.Now().UTC()); err != nil {
-			log.Printf("WARN set fallback_accessed_at for user %d: %v", user.ID, err)
+			log.Printf("WARN set fallback_accessed_at for user %d: %v", user.ID, err) //nolint:noctx // #nosec G706 -- user.ID is int, err is a db error
 		}
 	}()
 

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -82,18 +83,25 @@ func rateLimitMiddleware(perMin int) func(http.Handler) http.Handler {
 	}
 }
 
+// clientIP returns the real client IP. Forwarding headers (X-Forwarded-For,
+// X-Real-IP) are only trusted when the TCP connection originates from a local
+// proxy (127.0.0.1 or ::1). Any other caller setting these headers is treated
+// as the client itself, preventing rate-limit bypass via header injection.
 func clientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// First IP is the client when behind a proxy.
-		for i, c := range xff {
-			if c == ',' || c == ' ' {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if host == "127.0.0.1" || host == "::1" {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			if i := strings.IndexAny(xff, ", "); i >= 0 {
 				return strings.TrimSpace(xff[:i])
 			}
+			return strings.TrimSpace(xff)
 		}
-		return strings.TrimSpace(xff)
+		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+			return strings.TrimSpace(xri)
+		}
 	}
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return strings.TrimSpace(xri)
-	}
-	return r.RemoteAddr
+	return host
 }

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		xri        string
+		want       string
+	}{
+		{
+			name:       "direct connection, no headers",
+			remoteAddr: "1.2.3.4:50000",
+			want:       "1.2.3.4",
+		},
+		{
+			name:       "direct connection ignores XFF (spoof attempt)",
+			remoteAddr: "1.2.3.4:50000",
+			xff:        "9.9.9.9",
+			want:       "1.2.3.4",
+		},
+		{
+			name:       "direct connection ignores X-Real-IP (spoof attempt)",
+			remoteAddr: "1.2.3.4:50000",
+			xri:        "9.9.9.9",
+			want:       "1.2.3.4",
+		},
+		{
+			name:       "loopback proxy trusts XFF single IP",
+			remoteAddr: "127.0.0.1:12345",
+			xff:        "5.6.7.8",
+			want:       "5.6.7.8",
+		},
+		{
+			name:       "loopback proxy takes first IP from XFF list",
+			remoteAddr: "127.0.0.1:12345",
+			xff:        "5.6.7.8, 10.0.0.1, 172.16.0.1",
+			want:       "5.6.7.8",
+		},
+		{
+			name:       "loopback proxy trusts X-Real-IP when no XFF",
+			remoteAddr: "127.0.0.1:12345",
+			xri:        "5.6.7.8",
+			want:       "5.6.7.8",
+		},
+		{
+			name:       "loopback proxy prefers XFF over X-Real-IP",
+			remoteAddr: "127.0.0.1:12345",
+			xff:        "5.6.7.8",
+			xri:        "9.9.9.9",
+			want:       "5.6.7.8",
+		},
+		{
+			name:       "loopback proxy with no headers falls back to loopback",
+			remoteAddr: "127.0.0.1:12345",
+			want:       "127.0.0.1",
+		},
+		{
+			name:       "IPv6 loopback proxy trusts XFF",
+			remoteAddr: "[::1]:12345",
+			xff:        "5.6.7.8",
+			want:       "5.6.7.8",
+		},
+		{
+			name:       "IPv6 client ignores XFF",
+			remoteAddr: "[2001:db8::1]:50000",
+			xff:        "9.9.9.9",
+			want:       "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				r.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if tt.xri != "" {
+				r.Header.Set("X-Real-IP", tt.xri)
+			}
+			got := clientIP(r)
+			if got != tt.want {
+				t.Errorf("clientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -161,7 +161,9 @@ func (s *Server) rateLimitWrap(next http.Handler) http.Handler {
 func (s *Server) adminAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.cfg.AdminToken == "" {
-			next.ServeHTTP(w, r)
+			// No token configured — lock the API entirely rather than opening it.
+			// Set admin_token in config.json to enable the admin API.
+			jsonError(w, "admin API disabled: admin_token not configured", http.StatusServiceUnavailable)
 			return
 		}
 		token := r.Header.Get("X-Admin-Token")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -44,6 +44,9 @@ func NewServer(cfg *config.Config, db *database.DB, syncer Syncer) *Server {
 func (s *Server) Router() http.Handler {
 	r := mux.NewRouter()
 
+	// ── Fallback subscription endpoint (public, stable token, never rotated) ─
+	r.HandleFunc("/sub/fallback/{token}", s.handleFallbackSubscription).Methods(http.MethodGet)
+
 	// ── Subscription endpoint (public, authenticated by token) ──────────────
 	r.HandleFunc("/sub/{token}", s.handleSubscription).Methods(http.MethodGet)
 	r.HandleFunc("/sub/{token}/links", s.handleSubscriptionLinks).Methods(http.MethodGet)
@@ -116,6 +119,13 @@ func (s *Server) Router() http.Handler {
 	api.HandleFunc("/config/balancer", s.getBalancerConfig).Methods(http.MethodGet)
 	api.HandleFunc("/config/balancer", s.setBalancerConfig).Methods(http.MethodPut)
 	api.HandleFunc("/sync", s.triggerSync).Methods(http.MethodPost)
+
+	// ── Fallback management ───────────────────────────────────────────────────
+	api.HandleFunc("/users/{id}/fallback/token", s.regenerateFallbackToken).Methods(http.MethodPost)
+	api.HandleFunc("/fallback/status", s.getFallbackStatus).Methods(http.MethodGet)
+	api.HandleFunc("/fallback/enable", s.enableFallback).Methods(http.MethodPost)
+	api.HandleFunc("/fallback/disable", s.disableFallback).Methods(http.MethodPost)
+	api.HandleFunc("/fallback/accessed", s.listFallbackAccessedUsers).Methods(http.MethodGet)
 
 	// ── Emergency config rotation ─────────────────────────────────────────────
 	api.HandleFunc("/emergency/status", s.getEmergencyStatus).Methods(http.MethodGet)
@@ -277,6 +287,7 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 		balancerProbeInterval,
 		s.cfg.SocksInboundPort,
 		s.cfg.HTTPInboundPort,
+		s.cfg.ClientDNSServers,
 	)
 	if err != nil {
 		// #nosec G706 -- username is sanitized before logging.
@@ -459,7 +470,7 @@ func (s *Server) listUsers(w http.ResponseWriter, r *http.Request) {
 		resp = append(resp, models.UserResponse{
 			User:    u,
 			SubURL:  s.cfg.SubURL(u.Token),
-			SubURLs: s.cfg.SubURLs(u.Token),
+			SubURLs: s.cfg.SubURLsWithFallback(u.Token, u.FallbackToken),
 		})
 	}
 
@@ -500,8 +511,9 @@ func (s *Server) createUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	token := generateToken()
+	fallbackToken := generateToken()
 	// Email in DB mirrors username for Xray; not accepted on create and not exposed in API JSON.
-	user, err := s.db.CreateUser(username, "", token)
+	user, err := s.db.CreateUser(username, "", token, fallbackToken)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -541,7 +553,7 @@ func (s *Server) createUser(w http.ResponseWriter, r *http.Request) {
 		go func() { _ = s.syncer.Sync() }()
 	}
 
-	jsonOK(w, models.UserResponse{User: *user, SubURL: s.cfg.SubURL(user.Token), SubURLs: s.cfg.SubURLs(user.Token)})
+	jsonOK(w, models.UserResponse{User: *user, SubURL: s.cfg.SubURL(user.Token), SubURLs: s.cfg.SubURLsWithFallback(user.Token, user.FallbackToken)})
 }
 
 // addUserToInbound adds a user to one inbound (Xray + DB). Used when creating users.
@@ -717,7 +729,7 @@ func (s *Server) getUser(w http.ResponseWriter, r *http.Request) {
 	if user == nil || err != nil {
 		return
 	}
-	jsonOK(w, models.UserResponse{User: *user, SubURL: s.cfg.SubURL(user.Token), SubURLs: s.cfg.SubURLs(user.Token)})
+	jsonOK(w, models.UserResponse{User: *user, SubURL: s.cfg.SubURL(user.Token), SubURLs: s.cfg.SubURLsWithFallback(user.Token, user.FallbackToken)})
 }
 
 func (s *Server) deleteUser(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -393,3 +393,38 @@ func TestBuildSingboxClientConfig_Structure(t *testing.T) {
 	}
 }
 
+
+func TestAdminAuth_EmptyToken_Returns503(t *testing.T) {
+	dir := t.TempDir()
+	db, err := database.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	srv := NewServer(&config.Config{
+		ServerHost: "test.example.com",
+		BaseURL:    "http://test.example.com",
+		AdminToken: "", // empty — should lock the API
+	}, db, &noopSyncer{})
+
+	endpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/users"},
+		{http.MethodPost, "/api/users"},
+		{http.MethodGet, "/api/emergency/status"},
+		{http.MethodPost, "/api/emergency/activate"},
+		{http.MethodGet, "/api/inbounds"},
+	}
+
+	for _, e := range endpoints {
+		req := httptest.NewRequest(e.method, e.path, nil)
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, req)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("%s %s with empty token: got %d, want 503", e.method, e.path, rec.Code)
+		}
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -163,7 +163,7 @@ func (n *noopSyncer) Sync() error { return nil }
 // createTestUserWithHysteria2 creates a user and adds a hysteria2 client to DB.
 func createTestUserWithHysteria2(t *testing.T, db *database.DB, username string) (token string) {
 	t.Helper()
-	user, err := db.CreateUser(username, username, "tok-"+username)
+	user, err := db.CreateUser(username, username, "tok-"+username, "fb-"+username)
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -324,6 +324,7 @@ func (s *Server) generateConfigForSubscriptionRequestWithForcedProtocol(r *http.
 		balancerProbeInterval,
 		s.cfg.SocksInboundPort,
 		s.cfg.HTTPInboundPort,
+		s.cfg.ClientDNSServers,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("could not generate config: %s", err.Error())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,19 @@ type Config struct {
 	// Example: {"vless-reality-in": 8444} — clients connect to relay:8444 instead of EU:443
 	InboundPorts map[string]int `json:"inbound_ports,omitempty"`
 
+	// ClientDNSServers overrides the DNS server list in generated client configs.
+	// Each entry is either a plain IP string or an object with Xray DNS server fields:
+	//   address      — IP or hostname (required)
+	//   domains      — resolve only these domains via this server (geosite:/domain: syntax)
+	//   skipFallback — when true, server is excluded from the fallback list (List 2);
+	//                  use with domain-specific servers to prevent them handling unmatched domains
+	//   expectIPs    — accept only responses whose IPs match these ranges (geoip: syntax);
+	//                  mismatches are discarded and the next server is tried (anti-spoofing)
+	// When empty or omitted, a default list (1.1.1.1, 8.8.8.8, 8.8.4.4) is used.
+	// Example:
+	//   [{"address":"77.88.8.8","domains":["geosite:ru-blocked"],"skipFallback":true,"expectIPs":["geoip:ru"]},"1.1.1.1","9.9.9.9"]
+	ClientDNSServers []interface{} `json:"client_dns_servers,omitempty"`
+
 	// VLESSClientEncryption maps VLESS inbound tag to its client-side VLESS Encryption string.
 	// Required when the inbound uses VLESS Encryption (decryption != "none").
 	// Generate both strings with: xray vlessenc
@@ -220,7 +233,16 @@ func (c *Config) SubURL(token string) string {
 	return fmt.Sprintf("%s/sub/%s", c.BaseURL, token)
 }
 
+// FallbackURL returns the fallback subscription URL for the given fallback token.
+func (c *Config) FallbackURL(fallbackToken string) string {
+	if fallbackToken == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/sub/fallback/%s", c.BaseURL, fallbackToken)
+}
+
 // SubURLs returns all subscription URL variants for the given user token.
+// If fallbackToken is non-empty, the Fallback field is populated.
 func (c *Config) SubURLs(token string) models.SubURLs {
 	sub := fmt.Sprintf("%s/sub/%s", c.BaseURL, token)
 	compact := fmt.Sprintf("%s/c/%s", c.BaseURL, token)
@@ -234,6 +256,13 @@ func (c *Config) SubURLs(token string) models.SubURLs {
 		Singbox:     sub + "/singbox",
 		Hysteria2:   sub + "/hysteria2",
 	}
+}
+
+// SubURLsWithFallback returns all subscription URL variants including the fallback URL.
+func (c *Config) SubURLsWithFallback(token, fallbackToken string) models.SubURLs {
+	urls := c.SubURLs(token)
+	urls.Fallback = c.FallbackURL(fallbackToken)
+	return urls
 }
 
 func normalizeBalancerStrategy(v string) string {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -93,7 +93,6 @@ func (db *DB) migrate() error {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_users_token ON users(token);
-	CREATE INDEX IF NOT EXISTS idx_users_fallback_token ON users(fallback_token);
 	CREATE INDEX IF NOT EXISTS idx_user_clients_user ON user_clients(user_id);
 
 	CREATE TABLE IF NOT EXISTS emergency_profiles (
@@ -125,10 +124,13 @@ func (db *DB) migrate() error {
 	if _, err := db.conn.Exec(`UPDATE users SET email = username WHERE trim(COALESCE(email, '')) = ''`); err != nil {
 		return err
 	}
-	if _, err := db.conn.Exec(`ALTER TABLE users ADD COLUMN fallback_token TEXT UNIQUE DEFAULT NULL`); err != nil {
+	if _, err := db.conn.Exec(`ALTER TABLE users ADD COLUMN fallback_token TEXT DEFAULT NULL`); err != nil {
 		if !strings.Contains(err.Error(), "duplicate column name: fallback_token") {
 			return err
 		}
+	}
+	if _, err := db.conn.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_fallback_token ON users(fallback_token)`); err != nil {
+		return err
 	}
 	if _, err := db.conn.Exec(`ALTER TABLE users ADD COLUMN fallback_accessed_at DATETIME DEFAULT NULL`); err != nil {
 		if !strings.Contains(err.Error(), "duplicate column name: fallback_accessed_at") {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -93,6 +93,7 @@ func (db *DB) migrate() error {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_users_token ON users(token);
+	CREATE INDEX IF NOT EXISTS idx_users_fallback_token ON users(fallback_token);
 	CREATE INDEX IF NOT EXISTS idx_user_clients_user ON user_clients(user_id);
 
 	CREATE TABLE IF NOT EXISTS emergency_profiles (
@@ -124,30 +125,46 @@ func (db *DB) migrate() error {
 	if _, err := db.conn.Exec(`UPDATE users SET email = username WHERE trim(COALESCE(email, '')) = ''`); err != nil {
 		return err
 	}
+	if _, err := db.conn.Exec(`ALTER TABLE users ADD COLUMN fallback_token TEXT UNIQUE DEFAULT NULL`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name: fallback_token") {
+			return err
+		}
+	}
+	if _, err := db.conn.Exec(`ALTER TABLE users ADD COLUMN fallback_accessed_at DATETIME DEFAULT NULL`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name: fallback_accessed_at") {
+			return err
+		}
+	}
 	return nil
 }
 
 // ─── Users ───────────────────────────────────────────────────────────────────
 
 // CreateUser inserts a new user. If email is empty, it is set to username (Xray client email / monitoring).
-func (db *DB) CreateUser(username, email, token string) (*models.User, error) {
+// fallbackToken should be a pre-generated secure token; pass empty string to leave NULL.
+func (db *DB) CreateUser(username, email, token, fallbackToken string) (*models.User, error) {
 	username = strings.TrimSpace(username)
 	email = strings.TrimSpace(email)
 	if email == "" {
 		email = username
 	}
+	fallbackToken = strings.TrimSpace(fallbackToken)
 	now := time.Now().UTC()
+	var fallbackArg interface{}
+	if fallbackToken != "" {
+		fallbackArg = fallbackToken
+	}
 	res, err := db.conn.Exec(
-		`INSERT INTO users (username, email, token, enabled, client_routes, created_at, updated_at)
-		 VALUES (?, ?, ?, 1, '[]', ?, ?)`,
-		username, email, token, now, now,
+		`INSERT INTO users (username, email, token, fallback_token, enabled, client_routes, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 1, '[]', ?, ?)`,
+		username, email, token, fallbackArg, now, now,
 	)
 	if err != nil {
 		return nil, err
 	}
 	id, _ := res.LastInsertId()
 	return &models.User{
-		ID: id, Username: username, Email: email, Token: token, Enabled: true,
+		ID: id, Username: username, Email: email, Token: token, FallbackToken: fallbackToken, Enabled: true,
 		CreatedAt: now, UpdatedAt: now,
 	}, nil
 }
@@ -155,21 +172,31 @@ func (db *DB) CreateUser(username, email, token string) (*models.User, error) {
 // GetUserByToken returns the user matching the given subscription token, or nil if not found.
 func (db *DB) GetUserByToken(token string) (*models.User, error) {
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, enabled, client_routes, created_at, updated_at FROM users WHERE token = ?`, token,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE token = ?`, token,
+	))
+}
+
+// GetUserByFallbackToken returns the user matching the given fallback token, or nil if not found.
+func (db *DB) GetUserByFallbackToken(token string) (*models.User, error) {
+	if token == "" {
+		return nil, nil
+	}
+	return db.scanUser(db.conn.QueryRow(
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE fallback_token = ?`, token,
 	))
 }
 
 // GetUserByUsername returns the user with the given username, or nil if not found.
 func (db *DB) GetUserByUsername(username string) (*models.User, error) {
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, enabled, client_routes, created_at, updated_at FROM users WHERE username = ?`, username,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE username = ?`, username,
 	))
 }
 
 // GetUserByID returns the user with the given ID, or nil if not found.
 func (db *DB) GetUserByID(id int64) (*models.User, error) {
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, enabled, client_routes, created_at, updated_at FROM users WHERE id = ?`, id,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE id = ?`, id,
 	))
 }
 
@@ -180,7 +207,7 @@ func (db *DB) ListUsers() ([]models.User, error) {
 
 // ListUsersPaginated returns users with pagination. limit/offset 0 = no limit.
 func (db *DB) ListUsersPaginated(limit, offset int) ([]models.User, error) {
-	query := `SELECT id, username, email, token, enabled, client_routes, created_at, updated_at FROM users ORDER BY created_at`
+	query := `SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users ORDER BY created_at`
 	var args []interface{}
 	if limit > 0 {
 		query += ` LIMIT ? OFFSET ?`
@@ -225,6 +252,52 @@ func (db *DB) UpdateUserToken(userID int64, token string) error {
 	return err
 }
 
+// UpdateFallbackToken replaces the fallback token for the specified user.
+func (db *DB) UpdateFallbackToken(userID int64, fallbackToken string) error {
+	_, err := db.conn.Exec(
+		`UPDATE users SET fallback_token = ?, updated_at = ? WHERE id = ?`,
+		fallbackToken, time.Now().UTC(), userID,
+	)
+	return err
+}
+
+// SetFallbackAccessedAt records the time the fallback subscription was accessed.
+func (db *DB) SetFallbackAccessedAt(userID int64, t time.Time) error {
+	_, err := db.conn.Exec(
+		`UPDATE users SET fallback_accessed_at = ? WHERE id = ?`,
+		t.UTC(), userID,
+	)
+	return err
+}
+
+// GetFallbackEnabled returns true if the fallback subscription endpoint is globally enabled.
+// Defaults to true when no setting is stored.
+func (db *DB) GetFallbackEnabled() (bool, error) {
+	var val string
+	err := db.conn.QueryRow(`SELECT value FROM app_settings WHERE key = 'fallback_enabled'`).Scan(&val)
+	if err == sql.ErrNoRows {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return val != "false", nil
+}
+
+// SetFallbackEnabled sets the global fallback subscription enabled/disabled flag.
+func (db *DB) SetFallbackEnabled(enabled bool) error {
+	val := "true"
+	if !enabled {
+		val = "false"
+	}
+	_, err := db.conn.Exec(
+		`INSERT INTO app_settings (key, value) VALUES ('fallback_enabled', ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		val,
+	)
+	return err
+}
+
 // SetUserEnabled enables or disables the user account.
 func (db *DB) SetUserEnabled(userID int64, enabled bool) error {
 	_, err := db.conn.Exec(
@@ -245,7 +318,9 @@ func (db *DB) scanUser(row interface {
 }) (*models.User, error) {
 	var u models.User
 	var enabled int
-	err := row.Scan(&u.ID, &u.Username, &u.Email, &u.Token, &enabled, &u.ClientRoutes, &u.CreatedAt, &u.UpdatedAt)
+	var fallbackToken sql.NullString
+	var fallbackAccessedAt sql.NullTime
+	err := row.Scan(&u.ID, &u.Username, &u.Email, &u.Token, &fallbackToken, &fallbackAccessedAt, &enabled, &u.ClientRoutes, &u.CreatedAt, &u.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -253,6 +328,13 @@ func (db *DB) scanUser(row interface {
 		return nil, err
 	}
 	u.Enabled = enabled == 1
+	if fallbackToken.Valid {
+		u.FallbackToken = fallbackToken.String
+	}
+	if fallbackAccessedAt.Valid {
+		t := fallbackAccessedAt.Time
+		u.FallbackAccessedAt = &t
+	}
 	if strings.TrimSpace(u.Email) == "" {
 		u.Email = u.Username
 	}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -10,7 +10,7 @@ func TestDB_CreateUser_GetUserByID_GetUserByToken(t *testing.T) {
 	db, cleanup := testDB(t)
 	defer cleanup()
 
-	u, err := db.CreateUser("alice", "", "token-alice-123")
+	u, err := db.CreateUser("alice", "", "token-alice-123", "fallback-alice-123")
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestDB_DeleteUser(t *testing.T) {
 	db, cleanup := testDB(t)
 	defer cleanup()
 
-	u, err := db.CreateUser("bob", "", "token-bob")
+	u, err := db.CreateUser("bob", "", "token-bob", "fallback-bob")
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
@@ -105,8 +105,8 @@ func TestDB_ListUsers_CountUsers(t *testing.T) {
 		t.Errorf("initial count: got %d, want 0", n)
 	}
 
-	_, _ = db.CreateUser("u1", "", "t1")
-	_, _ = db.CreateUser("u2", "", "t2")
+	_, _ = db.CreateUser("u1", "", "t1", "fb1")
+	_, _ = db.CreateUser("u2", "", "t2", "fb2")
 
 	users, err := db.ListUsers()
 	if err != nil {
@@ -162,7 +162,7 @@ func TestDB_UpsertUserClient_GetUserClients(t *testing.T) {
 	db, cleanup := testDB(t)
 	defer cleanup()
 
-	u, _ := db.CreateUser("alice", "alice@example.com", "t-alice")
+	u, _ := db.CreateUser("alice", "alice@example.com", "t-alice", "fb-alice")
 	ibID, _ := db.UpsertInbound("vless-1", "vless", 443, "01.json", `{}`)
 
 	if err := db.UpsertUserClient(u.ID, ibID, `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision"}`); err != nil {
@@ -196,7 +196,7 @@ func TestDB_GetUserClientByUserAndInbound(t *testing.T) {
 	db, cleanup := testDB(t)
 	defer cleanup()
 
-	u, _ := db.CreateUser("alice", "", "t-alice")
+	u, _ := db.CreateUser("alice", "", "t-alice", "fb-alice2")
 	ibID, _ := db.UpsertInbound("vless-1", "vless", 443, "01.json", `{}`)
 	_ = db.UpsertUserClient(u.ID, ibID, `{"protocol":"vless","id":"uuid1"}`)
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -8,14 +8,16 @@ import (
 
 // User represents a subscription user stored in the database.
 type User struct {
-	ID        int64     `json:"id"`
-	Username  string    `json:"username"`
-	Email     string    `json:"-"` // Xray client email / monitoring; not exposed in API JSON (use username)
-	Token     string    `json:"token"`
-	Enabled   bool      `json:"enabled"`
-	ClientRoutes string `json:"-"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID              int64      `json:"id"`
+	Username        string     `json:"username"`
+	Email           string     `json:"-"` // Xray client email / monitoring; not exposed in API JSON (use username)
+	Token           string     `json:"token"`
+	FallbackToken   string     `json:"fallback_token"`
+	FallbackAccessedAt *time.Time `json:"fallback_accessed_at,omitempty"`
+	Enabled         bool       `json:"enabled"`
+	ClientRoutes    string     `json:"-"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
 }
 
 // ClientIdentity returns the Xray client "email" (API + JSON configs). Prefers Email when set.
@@ -81,6 +83,7 @@ type SubURLs struct {
 	CompactB64  string `json:"compact_b64"`
 	Singbox     string `json:"singbox,omitempty"`
 	Hysteria2   string `json:"hysteria2,omitempty"`
+	Fallback    string `json:"fallback,omitempty"`
 }
 
 // UserResponse is the API response body returned when a user is created or fetched.

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -301,7 +301,8 @@ func (s *Syncer) syncClient(inboundID int64, client xray.ParsedClient) error {
 	if user == nil {
 		// Auto-create user with generated token
 		token := generateToken()
-		user, err = s.db.CreateUser(identity, identity, token)
+		fallbackToken := generateToken()
+		user, err = s.db.CreateUser(identity, identity, token, fallbackToken)
 		if err != nil {
 			return fmt.Errorf("create user %s: %w", identity, err)
 		}

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -17,16 +17,20 @@ import (
 // socksPort and httpPort are the local proxy ports in the generated config; 0 = use default (2080, 1081).
 // inboundHosts overrides serverHost per inbound tag; falls back to serverHost when tag is not listed.
 // inboundPorts overrides the port per inbound tag; falls back to the inbound's own port when tag is not listed.
-func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inboundPorts map[string]int, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string, socksPort, httpPort int) (*ClientConfig, error) {
+func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inboundPorts map[string]int, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string, socksPort, httpPort int, dnsServers []interface{}) (*ClientConfig, error) {
 	if socksPort <= 0 {
 		socksPort = 2080
 	}
 	if httpPort <= 0 {
 		httpPort = 1081
 	}
+	dns := defaultDNS()
+	if len(dnsServers) > 0 {
+		dns = &DNSConfig{Servers: dnsServers}
+	}
 	cfg := &ClientConfig{
 		Log: &LogConfig{LogLevel: "warning"},
-		DNS: defaultDNS(),
+		DNS: dns,
 		Inbounds: []Inbound{
 			localSOCKS(socksPort),
 			localHTTP(httpPort),
@@ -605,11 +609,8 @@ func blackholeOutbound() Outbound {
 func defaultDNS() *DNSConfig {
 	return &DNSConfig{
 		Servers: []interface{}{
-			map[string]interface{}{
-				"address": "8.8.8.8",
-				"domains": []string{"geosite:google", "geosite:github"},
-			},
 			"1.1.1.1",
+			"8.8.8.8",
 			"8.8.4.4",
 		},
 	}
@@ -631,6 +632,12 @@ func defaultRouting() *Routing {
 			},
 			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:private"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:private"}},
+			// Route blocked Russian domains/IPs through the proxy (runetfreedom geosets,
+			// bundled in V2RayNG / Hiddify / NekoBox). Must come before geoip:ru direct rule.
+			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
+			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
+			// Unblocked Russian IPs go direct — reduces latency for domestic traffic.
+			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:ru"}},
 		},
 	}
 }

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -611,10 +611,6 @@ func defaultDNS() *DNSConfig {
 			},
 			"1.1.1.1",
 			"8.8.4.4",
-			map[string]interface{}{
-				"address": "223.5.5.5",
-				"domains": []string{"geosite:cn"},
-			},
 		},
 	}
 }
@@ -623,30 +619,10 @@ func defaultRouting() *Routing {
 	return &Routing{
 		DomainStrategy: "IPOnDemand",
 		Rules: []RoutingRule{
-			{
-				Type:        "field",
-				OutboundTag: "direct",
-				Domain: []string{
-					".lamoda.ru:443",
-					"okko.sport",
-					"okko.tv",
-					"yandex.net",
-					"vk.com",
-					"yastatic.net",
-					"gencit.info",
-					"naydex.net",
-					"deepseek.com",
-					"yandex.cloud",
-					"yandexcloud.net",
-					"lizaalert.org",
-					"selcdn.net",
-					"lk.dobroservice.com",
-					"dobroservice.com",
-				},
-			},
 			{Type: "field", OutboundTag: "direct", Protocol: []string{"bittorrent"}},
 			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
 			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
+			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:category-ru"}},
 			{
 				Type:        "field",
 				OutboundTag: "block",

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -620,6 +620,7 @@ func defaultRouting() *Routing {
 		DomainStrategy: "IPOnDemand",
 		Rules: []RoutingRule{
 			{Type: "field", OutboundTag: "direct", Protocol: []string{"bittorrent"}},
+			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:category-ru"}},
 			{
 				Type:        "field",
@@ -630,6 +631,7 @@ func defaultRouting() *Routing {
 					"geosite:category-public-tracker",
 				},
 			},
+			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
 			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:private"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:private"}},
 			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:ru"}},

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -620,8 +620,6 @@ func defaultRouting() *Routing {
 		DomainStrategy: "IPOnDemand",
 		Rules: []RoutingRule{
 			{Type: "field", OutboundTag: "direct", Protocol: []string{"bittorrent"}},
-			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
-			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:category-ru"}},
 			{
 				Type:        "field",

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -620,7 +620,6 @@ func defaultRouting() *Routing {
 		DomainStrategy: "IPOnDemand",
 		Rules: []RoutingRule{
 			{Type: "field", OutboundTag: "direct", Protocol: []string{"bittorrent"}},
-			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:category-ru"}},
 			{
 				Type:        "field",
 				OutboundTag: "block",
@@ -632,7 +631,6 @@ func defaultRouting() *Routing {
 			},
 			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:private"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:private"}},
-			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:ru"}},
 		},
 	}
 }

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -620,7 +620,6 @@ func defaultRouting() *Routing {
 		DomainStrategy: "IPOnDemand",
 		Rules: []RoutingRule{
 			{Type: "field", OutboundTag: "direct", Protocol: []string{"bittorrent"}},
-			{Type: "field", OutboundTag: "proxy", Domain: []string{"geosite:ru-blocked"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:category-ru"}},
 			{
 				Type:        "field",
@@ -631,7 +630,6 @@ func defaultRouting() *Routing {
 					"geosite:category-public-tracker",
 				},
 			},
-			{Type: "field", OutboundTag: "proxy", IP: []string{"geoip:ru-blocked"}},
 			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:private"}},
 			{Type: "field", OutboundTag: "direct", Domain: []string{"geosite:private"}},
 			{Type: "field", OutboundTag: "direct", IP: []string{"geoip:ru"}},

--- a/internal/xray/generator_test.go
+++ b/internal/xray/generator_test.go
@@ -23,7 +23,7 @@ func TestGenerateClientConfig(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestGenerateClientConfigCustomInboundPorts(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 31080, 31081)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 31080, 31081, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestGenerateClientConfigMultiProxy(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "leastPing", "https://www.gstatic.com/generate_204", "30s", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestGenerateClientConfigSingleProxy(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestGenerateClientConfigInvalidClientConfig(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid client config, got nil")
 	}
@@ -211,7 +211,7 @@ func TestGenerateClientConfigInvalidInboundRaw(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid inbound raw, got nil")
 	}
@@ -232,7 +232,7 @@ func TestGenerateClientConfigNoValidOutbounds(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err == nil {
 		t.Fatal("expected error for no valid outbounds, got nil")
 	}
@@ -258,7 +258,7 @@ func TestGenerateClientConfigWithGlobalRoutes(t *testing.T) {
 
 	globalRoutes := `[{"type":"field","outboundTag":"direct","domain":["geosite:ru"]}]`
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, globalRoutes, "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, globalRoutes, "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestGenerateClientConfigUserRoutes(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestGenerateClientConfigMuxEnabled(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestGenerateClientConfigNoMuxForREALITY(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestGenerateClientConfigShadowsocks(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestGenerateClientConfigTrojan(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestGenerateClientConfigSOCKS(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -517,7 +517,7 @@ func TestGenerateClientConfigMarshalJSON(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -556,7 +556,7 @@ func TestGenerateClientConfigPortParsing(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestGenerateClientConfigVLESSTestpre(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -635,7 +635,7 @@ func TestGenerateClientConfigVLESSTestpreZeroOmitted(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -684,7 +684,7 @@ func TestGenerateClientConfigXHTTPHostFromServerNames(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -711,5 +711,47 @@ func TestGenerateClientConfigXHTTPHostFromServerNames(t *testing.T) {
 	}
 	if host != "www.adobe.com" {
 		t.Fatalf("expected host 'www.adobe.com', got %q", host)
+	}
+}
+
+func TestGenerateClientConfigDNSServerFields(t *testing.T) {
+	dnsServers := []interface{}{
+		DNSServer{
+			Address:      "77.88.8.8",
+			Domains:      []string{"geosite:ru-blocked"},
+			SkipFallback: true,
+			ExpectIPs:    []string{"geoip:ru"},
+		},
+		"1.1.1.1",
+		"9.9.9.9",
+	}
+
+	clients := []models.UserClientFull{
+		{
+			UserClient: models.UserClient{
+				ClientConfig: `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision","encryption":"none"}`,
+			},
+			InboundTag:      "vless-1",
+			InboundProtocol: "vless",
+			InboundPort:     443,
+			InboundRaw:      `{"tag":"vless-1","protocol":"vless","port":443,"settings":{"decryption":"none","clients":[{"id":"uuid1","email":"user1@test.com","flow":"xtls-rprx-vision"}]},"streamSettings":{"network":"tcp"}}`,
+		},
+	}
+
+	cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, clients, "", "", "", "", 0, 0, dnsServers)
+	if err != nil {
+		t.Fatalf("GenerateClientConfig: %v", err)
+	}
+
+	raw, err := json.Marshal(cfg.DNS)
+	if err != nil {
+		t.Fatalf("marshal DNS: %v", err)
+	}
+	out := string(raw)
+
+	for _, want := range []string{"skipFallback", "expectIPs", "geoip:ru", "geosite:ru-blocked", "77.88.8.8", "9.9.9.9"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DNS JSON missing %q, got: %s", want, out)
+		}
 	}
 }

--- a/internal/xray/types.go
+++ b/internal/xray/types.go
@@ -237,6 +237,16 @@ type DNSConfig struct {
 	Servers []interface{} `json:"servers"`
 }
 
+// DNSServer is a structured DNS server entry for use in DNSConfig.Servers.
+// Plain string entries (IP addresses) are also valid; use this struct when
+// domain-specific routing, IP validation, or fallback control is needed.
+type DNSServer struct {
+	Address      string   `json:"address"`
+	Domains      []string `json:"domains,omitempty"`
+	SkipFallback bool     `json:"skipFallback,omitempty"`
+	ExpectIPs    []string `json:"expectIPs,omitempty"`
+}
+
 // Inbound (client local inbound - socks/http proxy)
 type Inbound struct {
 	Tag      string          `json:"tag"`


### PR DESCRIPTION
## Summary
- Per-user fallback subscription token: stable URL that doesn't change on rotation
- `DNSServer` struct with `skipFallback` and `expectIPs` fields for typed DNS config
- `client_dns_servers` config field now documents all supported Xray DNS server options
- Test coverage for DNS server serialization

## Test plan
- [ ] `go test ./internal/xray/... -run TestGenerateClientConfigDNSServerFields`
- [ ] `go test ./... -race -count=1`