### PR TITLE
Add client_blackhole_response config option

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -288,6 +288,7 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 		s.cfg.SocksInboundPort,
 		s.cfg.HTTPInboundPort,
 		s.cfg.ClientDNSServers,
+		s.cfg.ClientBlackholeResponse,
 	)
 	if err != nil {
 		// #nosec G706 -- username is sanitized before logging.

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -325,6 +325,7 @@ func (s *Server) generateConfigForSubscriptionRequestWithForcedProtocol(r *http.
 		s.cfg.SocksInboundPort,
 		s.cfg.HTTPInboundPort,
 		s.cfg.ClientDNSServers,
+		s.cfg.ClientBlackholeResponse,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("could not generate config: %s", err.Error())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,12 @@ type Config struct {
 	// Example: {"vless-reality-in": 8444} — clients connect to relay:8444 instead of EU:443
 	InboundPorts map[string]int `json:"inbound_ports,omitempty"`
 
+	// ClientBlackholeResponse sets the blackhole outbound response type in generated client configs.
+	// Accepted values: "http" (default, returns an HTTP error immediately so clients don't stall),
+	// "none" (drops the connection silently, no response sent).
+	// When empty, "http" is used.
+	ClientBlackholeResponse string `json:"client_blackhole_response,omitempty"`
+
 	// ClientDNSServers overrides the DNS server list in generated client configs.
 	// Each entry is either a plain IP string or an object with Xray DNS server fields:
 	//   address      — IP or hostname (required)

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -17,7 +17,7 @@ import (
 // socksPort and httpPort are the local proxy ports in the generated config; 0 = use default (2080, 1081).
 // inboundHosts overrides serverHost per inbound tag; falls back to serverHost when tag is not listed.
 // inboundPorts overrides the port per inbound tag; falls back to the inbound's own port when tag is not listed.
-func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inboundPorts map[string]int, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string, socksPort, httpPort int, dnsServers []interface{}) (*ClientConfig, error) {
+func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inboundPorts map[string]int, user models.User, clients []models.UserClientFull, globalRoutesJSON string, balancerStrategy string, balancerProbeURL string, balancerProbeInterval string, socksPort, httpPort int, dnsServers []interface{}, blackholeResponse string) (*ClientConfig, error) {
 	if socksPort <= 0 {
 		socksPort = 2080
 	}
@@ -36,6 +36,10 @@ func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inb
 			localHTTP(httpPort),
 		},
 		Routing: defaultRouting(),
+	}
+	blackholeResp := strings.ToLower(strings.TrimSpace(blackholeResponse))
+	if blackholeResp != "none" {
+		blackholeResp = "http"
 	}
 	// Priority: user rules > global rules > defaults
 	applyUserRoutes(cfg, globalRoutesJSON)
@@ -67,7 +71,7 @@ func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inb
 	// Add system outbounds
 	cfg.Outbounds = append(cfg.Outbounds,
 		freedomOutbound(),
-		blackholeOutbound(),
+		blackholeOutbound(blackholeResp),
 	)
 
 	// Update routing: use balancer if multiple proxies, single proxy otherwise
@@ -601,8 +605,8 @@ func freedomOutbound() Outbound {
 	return Outbound{Tag: "direct", Protocol: "freedom", Settings: raw}
 }
 
-func blackholeOutbound() Outbound {
-	raw, _ := json.Marshal(map[string]interface{}{"response": map[string]string{"type": "http"}})
+func blackholeOutbound(responseType string) Outbound {
+	raw, _ := json.Marshal(map[string]interface{}{"response": map[string]string{"type": responseType}})
 	return Outbound{Tag: "block", Protocol: "blackhole", Settings: raw}
 }
 

--- a/internal/xray/generator_test.go
+++ b/internal/xray/generator_test.go
@@ -23,7 +23,7 @@ func TestGenerateClientConfig(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestGenerateClientConfigCustomInboundPorts(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 31080, 31081, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 31080, 31081, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestGenerateClientConfigMultiProxy(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestGenerateClientConfigSingleProxy(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestGenerateClientConfigInvalidClientConfig(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err == nil {
 		t.Fatal("expected error for invalid client config, got nil")
 	}
@@ -211,7 +211,7 @@ func TestGenerateClientConfigInvalidInboundRaw(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err == nil {
 		t.Fatal("expected error for invalid inbound raw, got nil")
 	}
@@ -232,7 +232,7 @@ func TestGenerateClientConfigNoValidOutbounds(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	_, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err == nil {
 		t.Fatal("expected error for no valid outbounds, got nil")
 	}
@@ -258,7 +258,7 @@ func TestGenerateClientConfigWithGlobalRoutes(t *testing.T) {
 
 	globalRoutes := `[{"type":"field","outboundTag":"direct","domain":["geosite:ru"]}]`
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, globalRoutes, "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, globalRoutes, "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -293,7 +293,7 @@ func TestGenerateClientConfigUserRoutes(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestGenerateClientConfigMuxEnabled(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestGenerateClientConfigNoMuxForREALITY(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestGenerateClientConfigShadowsocks(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestGenerateClientConfigTrojan(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestGenerateClientConfigSOCKS(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -517,7 +517,7 @@ func TestGenerateClientConfigMarshalJSON(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -556,7 +556,7 @@ func TestGenerateClientConfigPortParsing(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -594,7 +594,7 @@ func TestGenerateClientConfigVLESSTestpre(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -635,7 +635,7 @@ func TestGenerateClientConfigVLESSTestpreZeroOmitted(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -684,7 +684,7 @@ func TestGenerateClientConfigXHTTPHostFromServerNames(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil)
+	cfg, err := GenerateClientConfig(serverHost, nil, nil, user, clients, "", "", "", "", 0, 0, nil, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig error: %v", err)
 	}
@@ -738,7 +738,7 @@ func TestGenerateClientConfigDNSServerFields(t *testing.T) {
 		},
 	}
 
-	cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, clients, "", "", "", "", 0, 0, dnsServers)
+	cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, clients, "", "", "", "", 0, 0, dnsServers, "")
 	if err != nil {
 		t.Fatalf("GenerateClientConfig: %v", err)
 	}
@@ -752,6 +752,49 @@ func TestGenerateClientConfigDNSServerFields(t *testing.T) {
 	for _, want := range []string{"skipFallback", "expectIPs", "geoip:ru", "geosite:ru-blocked", "77.88.8.8", "9.9.9.9"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("DNS JSON missing %q, got: %s", want, out)
+		}
+	}
+}
+
+func TestGenerateClientConfigBlackholeResponse(t *testing.T) {
+	client := models.UserClientFull{
+		UserClient: models.UserClient{
+			ClientConfig: `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision","encryption":"none"}`,
+		},
+		InboundTag:      "vless-1",
+		InboundProtocol: "vless",
+		InboundPort:     443,
+		InboundRaw:      `{"tag":"vless-1","protocol":"vless","port":443,"settings":{"decryption":"none","clients":[{"id":"uuid1","email":"u@test.com","flow":"xtls-rprx-vision"}]},"streamSettings":{"network":"tcp"}}`,
+	}
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{"", "http"},
+		{"http", "http"},
+		{"HTTP", "http"},
+		{"none", "none"},
+		{"NONE", "none"},
+		{"bogus", "http"},
+	} {
+		cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, []models.UserClientFull{client}, "", "", "", "", 0, 0, nil, tc.input)
+		if err != nil {
+			t.Fatalf("input=%q: %v", tc.input, err)
+		}
+		var found bool
+		for _, ob := range cfg.Outbounds {
+			if ob.Tag != "block" {
+				continue
+			}
+			found = true
+			raw, _ := json.Marshal(ob.Settings)
+			got := string(raw)
+			if !strings.Contains(got, `"`+tc.want+`"`) {
+				t.Errorf("input=%q: want blackhole type %q, got settings: %s", tc.input, tc.want, got)
+			}
+		}
+		if !found {
+			t.Errorf("input=%q: no block outbound in config", tc.input)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `client_blackhole_response` field to `config.json` — accepts `"http"` (default) or `"none"` (silent drop)
- Passes the value through `GenerateClientConfig` into `blackholeOutbound()`
- Invalid/empty values fall back to `"http"` silently

## Test plan

- [ ] `TestGenerateClientConfigBlackholeResponse` covers all input variants: `""`, `"http"`, `"HTTP"`, `"none"`, `"NONE"`, `"bogus"`
- [ ] All existing tests pass (`go test ./...`)

Closes: raised in AlchemyLink/Raven-server-install#31