### PR TITLE
fix: silence revive unused-parameter in core_test subtests

### DIFF
--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -17,7 +17,7 @@ import (
 // The test does not exercise behaviour — there is none yet. It guards the
 // public surface so accidental drift in Phase 2/3 is caught.
 func TestCoreInvariants(t *testing.T) {
-	t.Run("interfaces are declared", func(t *testing.T) {
+	t.Run("interfaces are declared", func(_ *testing.T) {
 		// Compile-time assertions that the four interfaces exist and that
 		// nil values can be typed against them. These will fail to compile
 		// (caught at `go vet`/`go build` time) if any signature drifts.
@@ -28,7 +28,7 @@ func TestCoreInvariants(t *testing.T) {
 		var _ core.EngineConfig
 	})
 
-	t.Run("value types are zero-constructible", func(t *testing.T) {
+	t.Run("value types are zero-constructible", func(_ *testing.T) {
 		_ = core.Inbound{}
 		_ = core.Client{}
 		_ = core.OutboundLink{}


### PR DESCRIPTION
## Why

CI on commit `80a28e6` (`core: add engine-agnostic interfaces (Phase 1)`) failed in the `golangci-lint Security Checks` job:

* `internal/core/core_test.go:20` — `unused-parameter: parameter 't' seems to be unused, consider removing or renaming it as _ (revive)`
* `internal/core/core_test.go:31` — same

The two subtests run only compile-time assertions (`var _ core.X`) or zero-constructions (`_ = core.X{}`) and never call any `t.*` method, so `revive` is technically right — `t` is unused.

## Fix

Rename `t *testing.T` → `_ *testing.T` in both subtest closures. Per `CONTRIBUTING.md` lint policy this is **P1 (must fix, low-risk)**.

## Behaviour change

None. The subtests still validate the same compile-time invariants. The other two subtests (`View enum stable order` + `no dependency on internal/xray`) keep `t` because they call `t.Fatalf`.

## Test

- Local Go 1.25.9, go.mod requires ≥1.26 → can't build/test locally; relying on CI.
- Functional change is zero — `_` as parameter name is purely a style/lint fix.