### PR TITLE
feat(hysteria): per-user hy2_enabled + pseudo-inbound for dashboard

### DIFF
--- a/internal/api/hysteria.go
+++ b/internal/api/hysteria.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 
+	"github.com/alchemylink/raven-subscribe/internal/config"
 	"github.com/gorilla/mux"
 )
 
@@ -106,6 +108,10 @@ func (s *Server) handleHysteriaSub(w http.ResponseWriter, r *http.Request, b64 b
 		jsonError(w, "user disabled", http.StatusForbidden)
 		return
 	}
+	if !user.Hy2Enabled {
+		jsonError(w, "hysteria2 reserve not enabled for this user", http.StatusForbidden)
+		return
+	}
 	h := s.cfg.Hysteria
 	uri := buildHysteria2URI(user.Token, "hy2-reserve", &HysteriaConfigView{
 		Host: h.Host, Port: h.Port, ObfsType: h.ObfsType, ObfsPassword: h.ObfsPassword, SNI: h.SNI, CertPin: h.CertPin,
@@ -126,12 +132,59 @@ func (s *Server) hysteriaMainSubExtra(token string) []string {
 		return nil
 	}
 	user, err := s.db.GetUserByToken(token)
-	if err != nil || user == nil || !user.Enabled {
+	if err != nil || user == nil || !user.Enabled || !user.Hy2Enabled {
 		return nil
 	}
 	return []string{buildHysteria2URI(user.Token, "hy2-reserve", &HysteriaConfigView{
 		Host: h.Host, Port: h.Port, ObfsType: h.ObfsType, ObfsPassword: h.ObfsPassword, SNI: h.SNI, CertPin: h.CertPin,
 	})}
+}
+
+// getUserHy2 (admin) returns whether the per-user Hysteria2 reserve is enabled.
+func (s *Server) getUserHy2(w http.ResponseWriter, r *http.Request) {
+	user, err := s.getByID(w, r)
+	if user == nil || err != nil {
+		return
+	}
+	jsonOK(w, map[string]bool{"hy2_enabled": user.Hy2Enabled})
+}
+
+// setUserHy2 (admin) toggles the per-user Hysteria2 reserve gate. Body: {"enabled": bool}.
+func (s *Server) setUserHy2(w http.ResponseWriter, r *http.Request) {
+	user, err := s.getByID(w, r)
+	if user == nil || err != nil {
+		return
+	}
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(limitRequestBody(r)).Decode(&body); err != nil {
+		jsonError(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+	if err := s.db.SetUserHy2Enabled(user.ID, body.Enabled); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]bool{"hy2_enabled": body.Enabled})
+}
+
+// hysteriaPseudoInbound renders the hysteria reserve as a synthetic inbound entry for the
+// /api/inbounds listing. It is NOT a real Xray inbound (id 0 + config_file "native-daemon"
+// + raw_config.pseudo signal that); the dashboard segregates it and gates it per-user via
+// the hy2_enabled flag, not via user_clients.
+func hysteriaPseudoInbound(h *config.HysteriaConfig) map[string]interface{} {
+	return map[string]interface{}{
+		"id":          0,
+		"tag":         "hysteria2-reserve",
+		"protocol":    "hysteria2",
+		"port":        h.Port,
+		"config_file": "native-daemon",
+		"updated_at":  time.Time{},
+		"raw_config": map[string]interface{}{
+			"tag": "hysteria2-reserve", "protocol": "hysteria2", "port": h.Port, "pseudo": true,
+		},
+	}
 }
 
 func requestFromLoopback(r *http.Request) bool {

--- a/internal/api/hysteria_test.go
+++ b/internal/api/hysteria_test.go
@@ -93,6 +93,74 @@ func TestHysteriaInMainSub(t *testing.T) {
 	})
 }
 
+func TestHysteriaPerUserGate(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+	hyTestUser(t, srv)
+	// Give alice a primary inbound+client so links.txt has content for hy2 to append to.
+	u, err := srv.db.GetUserByUsername("alice")
+	if err != nil || u == nil {
+		t.Fatalf("GetUserByUsername: %v", err)
+	}
+	xID, _ := srv.db.UpsertInbound("vless-xhttp-v2-in", "vless", 443, "210.json",
+		`{"tag":"vless-xhttp-v2-in","protocol":"vless","port":443,"streamSettings":{"network":"xhttp","security":"reality","realitySettings":{"serverNames":["www.python.org"],"publicKey":"testpublickey12345678901234567890123456789012","shortIds":["ab"]},"xhttpSettings":{"mode":"packet-up","host":"www.python.org","path":"/x"}}}`)
+	_ = srv.db.UpsertUserClient(u.ID, xID, `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision","encryption":"none"}`)
+	srv.cfg.Hysteria = &config.HysteriaConfig{
+		Enabled: true, Host: "zirgate.com", Port: 47014,
+		ObfsType: "salamander", ObfsPassword: "obfspw", SNI: "hy2.zirgate.com",
+		InMainSub: true,
+	}
+
+	subHy2 := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/sub/t-alice/hy2", nil)
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, req)
+		return rec.Code
+	}
+	setHy2 := func(enabled bool) int {
+		body, _ := json.Marshal(map[string]bool{"enabled": enabled})
+		req := httptest.NewRequest(http.MethodPut, "/api/users/alice/hy2", bytes.NewReader(body))
+		req.Header.Set("X-Admin-Token", "admin-secret")
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, req)
+		return rec.Code
+	}
+	links := func() string {
+		req := httptest.NewRequest(http.MethodGet, "/sub/t-alice/links.txt", nil)
+		rec := httptest.NewRecorder()
+		srv.Router().ServeHTTP(rec, req)
+		return rec.Body.String()
+	}
+
+	t.Run("default enabled -> 200 + hy2 in links", func(t *testing.T) {
+		if code := subHy2(); code != http.StatusOK {
+			t.Fatalf("default: got %d, want 200", code)
+		}
+		if !strings.Contains(links(), "hysteria2://") {
+			t.Error("default: hy2 missing from links")
+		}
+	})
+	t.Run("disable -> /hy2 403 + omitted from links", func(t *testing.T) {
+		if code := setHy2(false); code != http.StatusOK {
+			t.Fatalf("PUT disable: got %d, want 200", code)
+		}
+		if code := subHy2(); code != http.StatusForbidden {
+			t.Errorf("disabled /hy2: got %d, want 403", code)
+		}
+		if strings.Contains(links(), "hysteria2://") {
+			t.Error("disabled: hy2 leaked into links")
+		}
+	})
+	t.Run("re-enable -> 200 again", func(t *testing.T) {
+		if code := setHy2(true); code != http.StatusOK {
+			t.Fatalf("PUT enable: got %d, want 200", code)
+		}
+		if code := subHy2(); code != http.StatusOK {
+			t.Errorf("re-enabled /hy2: got %d, want 200", code)
+		}
+	})
+}
+
 func TestHysteriaSub(t *testing.T) {
 	srv, cleanup := testServer(t)
 	defer cleanup()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -125,6 +125,8 @@ func (s *Server) Router() http.Handler {
 	api.HandleFunc("/users/{id}/clients", s.addUserClient).Methods(http.MethodPost)
 	api.HandleFunc("/users/{id}/clients/{inboundId}/enable", s.enableUserClient).Methods(http.MethodPut)
 	api.HandleFunc("/users/{id}/clients/{inboundId}/disable", s.disableUserClient).Methods(http.MethodPut)
+	api.HandleFunc("/users/{id}/hy2", s.getUserHy2).Methods(http.MethodGet)
+	api.HandleFunc("/users/{id}/hy2", s.setUserHy2).Methods(http.MethodPut)
 
 	api.HandleFunc("/inbounds", s.listInbounds).Methods(http.MethodGet)
 	api.HandleFunc("/routes/global", s.getGlobalRoutes).Methods(http.MethodGet)
@@ -1563,6 +1565,13 @@ func (s *Server) listInbounds(w http.ResponseWriter, r *http.Request) {
 			"offset": offset,
 		})
 	} else {
+		// Hysteria2 runs as a separate native daemon (not in Xray config.d), so it never
+		// appears via the DB inbound sync. Surface it as a pseudo-inbound when enabled so
+		// the dashboard can list/offer it as a channel. The dashboard segregates it (it is
+		// not an Xray inbound — per-user control is the hy2_enabled flag, not user_clients).
+		if s.cfg.Hysteria != nil && s.cfg.Hysteria.Enabled {
+			resp = append(resp, hysteriaPseudoInbound(s.cfg.Hysteria))
+		}
 		jsonOK(w, resp)
 	}
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -138,6 +138,13 @@ func (db *DB) migrate() error {
 			return err
 		}
 	}
+	// Per-user Hysteria2 reserve gate. DEFAULT 1 → existing users keep hy2 on upgrade
+	// (matches the prior global-availability behaviour); operators disable per-user.
+	if _, err := db.conn.Exec(`ALTER TABLE users ADD COLUMN hy2_enabled INTEGER NOT NULL DEFAULT 1`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name: hy2_enabled") {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -168,14 +175,28 @@ func (db *DB) CreateUser(username, email, token, fallbackToken string) (*models.
 	id, _ := res.LastInsertId()
 	return &models.User{
 		ID: id, Username: username, Email: email, Token: token, FallbackToken: fallbackToken, Enabled: true,
+		Hy2Enabled: true, // DB column DEFAULT 1
 		CreatedAt: now, UpdatedAt: now,
 	}, nil
+}
+
+// SetUserHy2Enabled toggles the per-user Hysteria2 reserve gate.
+func (db *DB) SetUserHy2Enabled(userID int64, enabled bool) error {
+	v := 0
+	if enabled {
+		v = 1
+	}
+	_, err := db.conn.Exec(
+		`UPDATE users SET hy2_enabled = ?, updated_at = ? WHERE id = ?`,
+		v, time.Now().UTC(), userID,
+	)
+	return err
 }
 
 // GetUserByToken returns the user matching the given subscription token, or nil if not found.
 func (db *DB) GetUserByToken(token string) (*models.User, error) {
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE token = ?`, token,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, hy2_enabled, created_at, updated_at FROM users WHERE token = ?`, token,
 	))
 }
 
@@ -185,21 +206,21 @@ func (db *DB) GetUserByFallbackToken(token string) (*models.User, error) {
 		return nil, nil
 	}
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE fallback_token = ?`, token,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, hy2_enabled, created_at, updated_at FROM users WHERE fallback_token = ?`, token,
 	))
 }
 
 // GetUserByUsername returns the user with the given username, or nil if not found.
 func (db *DB) GetUserByUsername(username string) (*models.User, error) {
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE username = ?`, username,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, hy2_enabled, created_at, updated_at FROM users WHERE username = ?`, username,
 	))
 }
 
 // GetUserByID returns the user with the given ID, or nil if not found.
 func (db *DB) GetUserByID(id int64) (*models.User, error) {
 	return db.scanUser(db.conn.QueryRow(
-		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users WHERE id = ?`, id,
+		`SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, hy2_enabled, created_at, updated_at FROM users WHERE id = ?`, id,
 	))
 }
 
@@ -210,7 +231,7 @@ func (db *DB) ListUsers() ([]models.User, error) {
 
 // ListUsersPaginated returns users with pagination. limit/offset 0 = no limit.
 func (db *DB) ListUsersPaginated(limit, offset int) ([]models.User, error) {
-	query := `SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, created_at, updated_at FROM users ORDER BY created_at`
+	query := `SELECT id, username, email, token, fallback_token, fallback_accessed_at, enabled, client_routes, hy2_enabled, created_at, updated_at FROM users ORDER BY created_at`
 	var args []interface{}
 	if limit > 0 {
 		query += ` LIMIT ? OFFSET ?`
@@ -321,9 +342,10 @@ func (db *DB) scanUser(row interface {
 }) (*models.User, error) {
 	var u models.User
 	var enabled int
+	var hy2Enabled int
 	var fallbackToken sql.NullString
 	var fallbackAccessedAt sql.NullTime
-	err := row.Scan(&u.ID, &u.Username, &u.Email, &u.Token, &fallbackToken, &fallbackAccessedAt, &enabled, &u.ClientRoutes, &u.CreatedAt, &u.UpdatedAt)
+	err := row.Scan(&u.ID, &u.Username, &u.Email, &u.Token, &fallbackToken, &fallbackAccessedAt, &enabled, &u.ClientRoutes, &hy2Enabled, &u.CreatedAt, &u.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -331,6 +353,7 @@ func (db *DB) scanUser(row interface {
 		return nil, err
 	}
 	u.Enabled = enabled == 1
+	u.Hy2Enabled = hy2Enabled == 1
 	if fallbackToken.Valid {
 		u.FallbackToken = fallbackToken.String
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -15,6 +15,9 @@ type User struct {
 	FallbackToken   string     `json:"fallback_token"`
 	FallbackAccessedAt *time.Time `json:"fallback_accessed_at,omitempty"`
 	Enabled         bool       `json:"enabled"`
+	// Hy2Enabled gates the per-user Hysteria2 reserve (/sub/{token}/hy2 and the hy2 URI
+	// folded into the main link-list). Defaults to true for all users (DB column DEFAULT 1).
+	Hy2Enabled      bool       `json:"hy2_enabled"`
 	ClientRoutes    string     `json:"-"`
 	CreatedAt       time.Time  `json:"created_at"`
 	UpdatedAt       time.Time  `json:"updated_at"`


### PR DESCRIPTION
Per-user Hysteria2 reserve gate + surface it as a channel for the dashboard.

- `users.hy2_enabled` column (migration, DEFAULT 1 — existing users keep hy2)
- model + scanUser + `SetUserHy2Enabled`; `GET/PUT /api/users/{id}/hy2`
- `handleHysteriaSub` 403 + `hysteriaMainSubExtra` omit when disabled
- `listInbounds` appends a `hysteria2-reserve` pseudo-inbound when the reserve is enabled (native daemon, not in config.d)
- `TestHysteriaPerUserGate`

Pairs with raven-dashboard feat/hy2-per-user (per-user toggle UI + live inbound SSE).