### PR TITLE
feat(observability): killswitch transition logging + /metrics fallback gauges

### DIFF
--- a/internal/api/fallback.go
+++ b/internal/api/fallback.go
@@ -32,6 +32,7 @@ func (s *Server) withFallbackAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 		if !enabled {
+			s.fallbackDenied.Add(1)
 			jsonError(w, "fallback subscription disabled", http.StatusForbidden)
 			return
 		}
@@ -213,7 +214,11 @@ func (s *Server) applyKillSwitchInboundsLocked(enable bool) {
 					continue
 				}
 				log.Printf("WARN killswitch enable: AddInbound %s: %v", sanitizeLogField(tag), err)
+				continue
 			}
+			// Log actual additions: this is the only record that a runtime inbound
+			// came back. Fires once per real transition, not per reconcile tick.
+			log.Printf("INFO killswitch enable: added inbound %s to runtime", sanitizeLogField(tag))
 			continue
 		}
 		// disable
@@ -229,7 +234,12 @@ func (s *Server) applyKillSwitchInboundsLocked(enable bool) {
 				continue
 			}
 			log.Printf("WARN killswitch disable: RemoveInbound %s: %v", sanitizeLogField(tag), err)
+			continue
 		}
+		// Log actual removals: during incident 2026-06-09 inbounds vanished from the
+		// runtime with zero log evidence because successful RemoveInbound was silent
+		// (only the "already absent" idiom logged). Fires once per real transition.
+		log.Printf("INFO killswitch disable: removed inbound %s from runtime", sanitizeLogField(tag))
 	}
 }
 

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// MetricsHandler serves a minimal Prometheus text-format exposition endpoint.
+// Hand-rolled on purpose: two series do not justify a client_golang dependency.
+//
+// Serve this on a SEPARATE listener (config metrics_listen), never on the main
+// router — the main router is publicly reachable through the subscription vhost.
+//
+// raven_fallback_enabled directly encodes the Fallback Model A invariant
+// (enabled=1 is the steady state); monitoring alerts when it stays 0 outside a
+// sanitization window. raven_fallback_denied_total counts user-facing 403s from
+// the disabled fallback, i.e. real client impact.
+func (s *Server) MetricsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		enabled, err := s.db.GetFallbackEnabled()
+		if err != nil {
+			log.Printf("ERROR metrics: get fallback enabled: %v", err)
+			http.Error(w, "db error", http.StatusInternalServerError)
+			return
+		}
+		enabledVal := 0
+		if enabled {
+			enabledVal = 1
+		}
+		body := fmt.Sprintf(
+			"# HELP raven_fallback_enabled Global fallback subscription flag (1 = enabled, the Model A steady state).\n"+
+				"# TYPE raven_fallback_enabled gauge\n"+
+				"raven_fallback_enabled %d\n"+
+				"# HELP raven_fallback_denied_total Fallback subscription requests rejected with 403 because the global flag is off. Resets on restart.\n"+
+				"# TYPE raven_fallback_denied_total counter\n"+
+				"raven_fallback_denied_total %d\n",
+			enabledVal, s.fallbackDenied.Load())
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	}
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMetrics_FallbackEnabledGauge(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+
+	if err := srv.db.SetFallbackEnabled(true); err != nil {
+		t.Fatalf("SetFallbackEnabled: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	srv.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "raven_fallback_enabled 1") {
+		t.Errorf("enabled=true: body should contain raven_fallback_enabled 1, got:\n%s", rec.Body.String())
+	}
+
+	if err := srv.db.SetFallbackEnabled(false); err != nil {
+		t.Fatalf("SetFallbackEnabled: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	srv.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec.Body.String(), "raven_fallback_enabled 0") {
+		t.Errorf("enabled=false: body should contain raven_fallback_enabled 0, got:\n%s", rec.Body.String())
+	}
+}
+
+func TestMetrics_FallbackDeniedCounterIncrements(t *testing.T) {
+	srv, cleanup := testServer(t)
+	defer cleanup()
+
+	if err := srv.db.SetFallbackEnabled(false); err != nil {
+		t.Fatalf("SetFallbackEnabled: %v", err)
+	}
+
+	router := srv.Router()
+	for i := 0; i < 3; i++ {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/sub/fallback/sometoken", nil))
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("fallback request %d: status = %d, want 403", i, rec.Code)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	srv.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec.Body.String(), "raven_fallback_denied_total 3") {
+		t.Errorf("body should contain raven_fallback_denied_total 3, got:\n%s", rec.Body.String())
+	}
+
+	// Enabled fallback with an unknown token is a 404, not a denial — counter must not move.
+	if err := srv.db.SetFallbackEnabled(true); err != nil {
+		t.Fatalf("SetFallbackEnabled: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/sub/fallback/sometoken", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("enabled+unknown token: status = %d, want 404", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	srv.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec.Body.String(), "raven_fallback_denied_total 3") {
+		t.Errorf("counter must stay at 3 after non-denial, got:\n%s", rec.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gorilla/mux"
 	"github.com/alchemylink/raven-subscribe/internal/config"
@@ -42,6 +43,11 @@ type Server struct {
 	// handlers so the periodic reconcile loop cannot race a concurrent
 	// enable/disable into a flipped runtime state.
 	killSwitchMu sync.Mutex
+	// fallbackDenied counts /sub/fallback/* and /c/fallback/* requests rejected
+	// with 403 because the global fallback flag is off. Exposed on /metrics so
+	// monitoring can alert on users hitting a disabled fallback (a forgotten
+	// sanitization window). Resets on restart — alert on increase(), not value.
+	fallbackDenied atomic.Int64
 }
 
 // NewServer creates a new Server with the given config, database, and syncer.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,12 @@ type HysteriaConfig struct {
 
 // Config holds all runtime configuration for the xray-subscription service.
 type Config struct {
-	ListenAddr        string `json:"listen_addr"`
+	ListenAddr string `json:"listen_addr"`
+	// MetricsListen, when set (e.g. "127.0.0.1:9091"), serves Prometheus metrics
+	// at /metrics on a dedicated listener. Deliberately separate from ListenAddr:
+	// the main router is publicly reachable through the subscription vhost, and
+	// metrics must never be. Empty = metrics disabled.
+	MetricsListen     string `json:"metrics_listen,omitempty"`
 	ServerHost        string `json:"server_host"`
 	ConfigDir         string `json:"config_dir"`
 	DBPath            string `json:"db_path"`

--- a/main.go
+++ b/main.go
@@ -100,6 +100,26 @@ func main() {
 		}
 	}()
 
+	// ── Metrics Server (separate listener — never exposed via the sub vhost) ──
+	var metricsServer *http.Server
+	if cfg.MetricsListen != "" {
+		mm := http.NewServeMux()
+		mm.HandleFunc("/metrics", srv.MetricsHandler())
+		metricsServer = &http.Server{
+			Addr:         cfg.MetricsListen,
+			Handler:      mm,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		}
+		go func() {
+			log.Printf("Metrics listening on %s/metrics", cfg.MetricsListen)
+			if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("Metrics server error: %v", err)
+			}
+		}()
+	}
+
 	// ── Graceful Shutdown ───────────────────────────────────────────────────
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
@@ -111,6 +131,11 @@ func main() {
 	defer cancel()
 	if err := httpServer.Shutdown(ctx); err != nil {
 		log.Printf("HTTP shutdown error: %v", err)
+	}
+	if metricsServer != nil {
+		if err := metricsServer.Shutdown(ctx); err != nil {
+			log.Printf("Metrics shutdown error: %v", err)
+		}
 	}
 	log.Println("Stopped")
 }


### PR DESCRIPTION
## Why

During the 2026-06-09 incident the global fallback flag was left disabled for two days (second occurrence of the rollback-gap pattern). Two observability holes made it invisible:

1. **Silent runtime transitions** — successful `RemoveInbound`/`AddInbound` gRPC calls logged nothing; only the benign "already absent/present" idioms did. The killswitch removed `vless-fallback-in` from the Xray runtime with zero log evidence of the actual removal.
2. **No monitoring signal** — users got 403 on every fallback subscription fetch; nothing alerted.

## What

- Log every actual killswitch add/remove of a runtime inbound. Fires once per real transition, not per 30s reconcile tick.
- New `metrics_listen` config field: dedicated Prometheus text-format listener serving `/metrics` (hand-rolled, no client_golang dep). Deliberately a separate listener — the main router is publicly reachable through the sub vhost.
- `raven_fallback_enabled` gauge — encodes the Fallback Model A invariant (1 = steady state); alert when it stays 0 outside a sanitization window.
- `raven_fallback_denied_total` counter — fallback requests 403'd by the global flag (real client impact). Resets on restart; alert on `increase()`.

Companion Ansible change (scrape job + Grafana alert rules) goes to Raven-server-install separately.

## Testing

- `go test ./... -race` green, including new `metrics_test.go` (gauge follows flag; counter increments only on flag-denials, not 404s).
- golangci-lint / staticcheck / gosec clean.