### PR TITLE
feat(sub): emit XHTTP extra (xmux) in vless:// URI for v2rayN clients only

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -365,12 +365,13 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 
 	format := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("format")))
 	hyExtra := s.hysteriaMainSubExtra(user.Token)
+	emitXHTTPExtra := clientSupportsXHTTPExtra(r)
 	if format == "v2box" || format == "links" || format == "links.txt" {
-		writeProxyLinksText(w, user.Username, cfg, hyExtra)
+		writeProxyLinksText(w, user.Username, cfg, emitXHTTPExtra, hyExtra)
 		return
 	}
 	if format == "b64" || format == "links.b64" {
-		writeProxyLinksB64(w, user.Username, cfg, hyExtra)
+		writeProxyLinksB64(w, user.Username, cfg, emitXHTTPExtra, hyExtra)
 		return
 	}
 

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/alchemylink/raven-subscribe/internal/models"
 	"github.com/alchemylink/raven-subscribe/internal/xray"
+	"github.com/gorilla/mux"
 )
 
 type proxyLink struct {
@@ -67,17 +67,17 @@ func (s *Server) handleVLESSList(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	entries := buildProxyLinkEntries(cfg)
+	entries := buildProxyLinkEntries(cfg, clientSupportsXHTTPExtra(r))
 	list := make([]map[string]string, 0, len(entries))
 	for _, e := range entries {
 		if e.Protocol != "vless" {
 			continue
 		}
 		list = append(list, map[string]string{
-			"tag":      e.Tag,
-			"url":      e.URL,
-			"url_b64":  base64.StdEncoding.EncodeToString([]byte(e.URL)),
-			"by_tag":   fmt.Sprintf("%s/vless/%s", strings.TrimSuffix(extractSubBaseURL(r), "/"), url.PathEscape(e.Tag)),
+			"tag":        e.Tag,
+			"url":        e.URL,
+			"url_b64":    base64.StdEncoding.EncodeToString([]byte(e.URL)),
+			"by_tag":     fmt.Sprintf("%s/vless/%s", strings.TrimSuffix(extractSubBaseURL(r), "/"), url.PathEscape(e.Tag)),
 			"by_tag_b64": fmt.Sprintf("%s/vless/%s/b64", strings.TrimSuffix(extractSubBaseURL(r), "/"), url.PathEscape(e.Tag)),
 		})
 	}
@@ -107,7 +107,7 @@ func (s *Server) handleVLESSLinkByTag(w http.ResponseWriter, r *http.Request, fo
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	entries := buildProxyLinkEntries(cfg)
+	entries := buildProxyLinkEntries(cfg, clientSupportsXHTTPExtra(r))
 	for _, e := range entries {
 		if e.Protocol != "vless" {
 			continue
@@ -141,11 +141,12 @@ func (s *Server) handleSubscriptionLinksByFormatAndProtocol(w http.ResponseWrite
 	if forcedProtocol == "" {
 		extra = s.hysteriaMainSubExtra(mux.Vars(r)["token"])
 	}
+	emitXHTTPExtra := clientSupportsXHTTPExtra(r)
 	if format == "b64" {
-		writeProxyLinksB64(w, username, cfg, extra)
+		writeProxyLinksB64(w, username, cfg, emitXHTTPExtra, extra)
 		return
 	}
-	writeProxyLinksText(w, username, cfg, extra)
+	writeProxyLinksText(w, username, cfg, emitXHTTPExtra, extra)
 }
 
 // filterExcludedInbounds drops clients whose inbound tag is in cfg.ExcludeInboundTags.
@@ -233,8 +234,8 @@ func matchesInboundTagFilter(inboundTag, filter string, index int) bool {
 	return fmt.Sprintf("%s-%d", sanitized, index) == filter
 }
 
-func writeProxyLinksText(w http.ResponseWriter, username string, cfg *xray.ClientConfig, extra ...[]string) {
-	links := append(buildProxyLinks(cfg), flattenExtra(extra)...)
+func writeProxyLinksText(w http.ResponseWriter, username string, cfg *xray.ClientConfig, emitXHTTPExtra bool, extra ...[]string) {
+	links := append(buildProxyLinks(cfg, emitXHTTPExtra), flattenExtra(extra)...)
 	payload := strings.Join(links, "\n")
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Profile-Title", username)
@@ -251,8 +252,8 @@ func flattenExtra(extra [][]string) []string {
 	return out
 }
 
-func writeProxyLinksB64(w http.ResponseWriter, username string, cfg *xray.ClientConfig, extra ...[]string) {
-	links := append(buildProxyLinks(cfg), flattenExtra(extra)...)
+func writeProxyLinksB64(w http.ResponseWriter, username string, cfg *xray.ClientConfig, emitXHTTPExtra bool, extra ...[]string) {
+	links := append(buildProxyLinks(cfg, emitXHTTPExtra), flattenExtra(extra)...)
 	plain := strings.Join(links, "\n")
 	payload := base64.StdEncoding.EncodeToString([]byte(plain))
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -261,8 +262,8 @@ func writeProxyLinksB64(w http.ResponseWriter, username string, cfg *xray.Client
 	_, _ = w.Write([]byte(payload))
 }
 
-func buildProxyLinks(cfg *xray.ClientConfig) []string {
-	entries := buildProxyLinkEntries(cfg)
+func buildProxyLinks(cfg *xray.ClientConfig, emitXHTTPExtra bool) []string {
+	entries := buildProxyLinkEntries(cfg, emitXHTTPExtra)
 	links := make([]string, 0, len(entries))
 	for _, e := range entries {
 		links = append(links, e.URL)
@@ -270,7 +271,7 @@ func buildProxyLinks(cfg *xray.ClientConfig) []string {
 	return links
 }
 
-func buildProxyLinkEntries(cfg *xray.ClientConfig) []proxyLink {
+func buildProxyLinkEntries(cfg *xray.ClientConfig, emitXHTTPExtra bool) []proxyLink {
 	if cfg == nil {
 		return nil
 	}
@@ -278,7 +279,7 @@ func buildProxyLinkEntries(cfg *xray.ClientConfig) []proxyLink {
 	for _, ob := range cfg.Outbounds {
 		switch ob.Protocol {
 		case "vless":
-			if l := buildVLESSLink(ob); l != "" {
+			if l := buildVLESSLink(ob, emitXHTTPExtra); l != "" {
 				links = append(links, proxyLink{Protocol: "vless", Tag: ob.Tag, URL: l})
 			}
 		case "vmess":
@@ -286,7 +287,7 @@ func buildProxyLinkEntries(cfg *xray.ClientConfig) []proxyLink {
 				links = append(links, proxyLink{Protocol: "vmess", Tag: ob.Tag, URL: l})
 			}
 		case "trojan":
-			if l := buildTrojanLink(ob); l != "" {
+			if l := buildTrojanLink(ob, emitXHTTPExtra); l != "" {
 				links = append(links, proxyLink{Protocol: "trojan", Tag: ob.Tag, URL: l})
 			}
 		case "shadowsocks":
@@ -387,7 +388,7 @@ func extractSubBaseURL(r *http.Request) string {
 	return fmt.Sprintf("%s://%s/sub/%s", scheme, host, token)
 }
 
-func buildVLESSLink(ob xray.Outbound) string {
+func buildVLESSLink(ob xray.Outbound, emitXHTTPExtra bool) string {
 	var s xray.VLESSOutboundSettings
 	if err := json.Unmarshal(ob.Settings, &s); err != nil || len(s.Vnext) == 0 || len(s.Vnext[0].Users) == 0 {
 		return ""
@@ -428,7 +429,7 @@ func buildVLESSLink(ob xray.Outbound) string {
 		if ob.StreamSettings.Security == "tls" && ob.StreamSettings.TLSSettings != nil {
 			applyTLSCertParams(params, ob.StreamSettings.TLSSettings)
 		}
-		applyTransportParams(params, ob.StreamSettings)
+		applyTransportParams(params, ob.StreamSettings, emitXHTTPExtra)
 	}
 	if fm := extractFinalmask(ob.Settings); fm != "" {
 		params.Set("fm", fm)
@@ -445,14 +446,14 @@ func buildVMessLink(ob xray.Outbound) string {
 	vn := s.Vnext[0]
 	u := s.Vnext[0].Users[0]
 	item := map[string]string{
-		"v":   "2",
-		"ps":  ob.Tag,
-		"add": vn.Address,
+		"v":    "2",
+		"ps":   ob.Tag,
+		"add":  vn.Address,
 		"port": strconv.Itoa(vn.Port),
-		"id":  u.ID,
-		"aid": strconv.Itoa(u.AlterId),
-		"scy": firstNonEmptyString(u.Security, "auto"),
-		"net": "tcp",
+		"id":   u.ID,
+		"aid":  strconv.Itoa(u.AlterId),
+		"scy":  firstNonEmptyString(u.Security, "auto"),
+		"net":  "tcp",
 		"type": "none",
 		"host": "",
 		"path": "",
@@ -482,7 +483,7 @@ func buildVMessLink(ob xray.Outbound) string {
 	return "vmess://" + base64.StdEncoding.EncodeToString(raw)
 }
 
-func buildTrojanLink(ob xray.Outbound) string {
+func buildTrojanLink(ob xray.Outbound, emitXHTTPExtra bool) string {
 	var s xray.TrojanOutboundSettings
 	if err := json.Unmarshal(ob.Settings, &s); err != nil || len(s.Servers) == 0 {
 		return ""
@@ -503,7 +504,7 @@ func buildTrojanLink(ob xray.Outbound) string {
 			}
 			applyTLSCertParams(params, ob.StreamSettings.TLSSettings)
 		}
-		applyTransportParams(params, ob.StreamSettings)
+		applyTransportParams(params, ob.StreamSettings, emitXHTTPExtra)
 	}
 	if fm := extractFinalmask(ob.Settings); fm != "" {
 		params.Set("fm", fm)
@@ -522,7 +523,24 @@ func buildSSLink(ob xray.Outbound) string {
 	return fmt.Sprintf("ss://%s@%s:%d#%s", cred, sv.Address, sv.Port, url.QueryEscape(ob.Tag))
 }
 
-func applyTransportParams(params url.Values, ss *xray.StreamSettings) {
+// clientSupportsXHTTPExtra reports whether the requesting client can be trusted with
+// the vless:// `extra` query param (xmux + xPaddingBytes) WITHOUT breaking the
+// connection. Only v2rayN/v2rayNG have mature XHTTP+xmux support and parse `extra`
+// correctly. Xray-core-embedded mobile clients (Happ, Streisand, INCY) accept and even
+// display the param but then fail to connect on XHTTP+xmux — the handshake completes
+// but no HTTP data flows (XTLS/Xray-core#5918, #6048; open / can't-reproduce upstream,
+// version-coupling sensitive). sing-box/libXray clients don't parse `extra` at all
+// (XTLS/libXray#62). So we emit `extra` ONLY for v2rayN-family User-Agents; everyone
+// else gets the clean URI (connects fine, just without the anti-volumetric xmux lever).
+// "v2rayn" is a substring of both "v2rayn/x.y" and "v2rayng/x.y" (case-insensitive).
+func clientSupportsXHTTPExtra(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(r.UserAgent()), "v2rayn")
+}
+
+func applyTransportParams(params url.Values, ss *xray.StreamSettings, emitXHTTPExtra bool) {
 	if ss == nil {
 		return
 	}
@@ -555,6 +573,22 @@ func applyTransportParams(params url.Values, ss *xray.StreamSettings) {
 			}
 			if v, ok := xh["mode"].(string); ok && v != "" {
 				params.Set("mode", v)
+			}
+			// "extra" carries the client-side advanced fields (xmux, xPaddingBytes,
+			// scMaxEachPostBytes, ...). vless:// URIs historically dropped it, so the
+			// mux + anti-volumetric levers never reached URI-import clients
+			// (v2rayN/v2rayNG) — the prod root cause of the M1 download freeze on
+			// mobile DPI (proven 2026-06-10: no-xmux stalls 4/5, with-xmux 5/5 clean).
+			// v2rayN parses a URL-encoded JSON `extra` query param; emit it so URI subs
+			// carry xmux too — but ONLY for clients that handle it (emitXHTTPExtra,
+			// gated on User-Agent via clientSupportsXHTTPExtra). Emitting it to Happ/
+			// libXray/sing-box clients breaks the connection (XTLS/Xray-core#5918,#6048).
+			if emitXHTTPExtra {
+				if ex, ok := xh["extra"].(map[string]interface{}); ok && len(ex) > 0 {
+					if b, err := json.Marshal(ex); err == nil {
+						params.Set("extra", string(b))
+					}
+				}
 			}
 		}
 	}

--- a/internal/api/sub_links_test.go
+++ b/internal/api/sub_links_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -66,7 +68,7 @@ func TestBuildVLESSLink_FinalmaskEmitted(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob)
+	link := buildVLESSLink(ob, false)
 	params := parseLinkParams(t, link)
 	got := params.Get("fm")
 	if got == "" {
@@ -97,7 +99,7 @@ func TestBuildVLESSLink_FinalmaskAbsent_NoFM(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob)
+	link := buildVLESSLink(ob, false)
 	if got := parseLinkParams(t, link).Get("fm"); got != "" {
 		t.Errorf("expected no fm parameter, got %q (link=%s)", got, link)
 	}
@@ -119,7 +121,7 @@ func TestBuildVLESSLink_TLSPCSVCNEmitted(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob)
+	link := buildVLESSLink(ob, false)
 	params := parseLinkParams(t, link)
 	if got := params.Get("pcs"); got != "AAAA1111,BBBB2222" {
 		t.Errorf("pcs: got %q, want %q", got, "AAAA1111,BBBB2222")
@@ -152,13 +154,138 @@ func TestBuildVLESSLink_RealityNoPCSVCN(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob)
+	link := buildVLESSLink(ob, false)
 	params := parseLinkParams(t, link)
 	if got := params.Get("pcs"); got != "" {
 		t.Errorf("pcs should be empty under security=reality, got %q", got)
 	}
 	if got := params.Get("vcn"); got != "" {
 		t.Errorf("vcn should be empty under security=reality, got %q", got)
+	}
+}
+
+func xhttpStreamSettings(t *testing.T, withExtra bool) json.RawMessage {
+	t.Helper()
+	xh := map[string]interface{}{
+		"path": "/api/v4/sync",
+		"host": "www.python.org",
+		"mode": "packet-up",
+	}
+	if withExtra {
+		xh["extra"] = map[string]interface{}{
+			"xPaddingBytes": "100-1000",
+			"xmux": map[string]interface{}{
+				"maxConcurrency": "16-32",
+				"cMaxReuseTimes": "64-128",
+			},
+		}
+	}
+	raw, err := json.Marshal(xh)
+	if err != nil {
+		t.Fatalf("marshal xhttp settings: %v", err)
+	}
+	return raw
+}
+
+// The vless:// URI must carry the xhttp "extra" (xmux + xPaddingBytes) so URI-import
+// clients (v2rayN) receive the anti-volumetric levers. Dropping it was the prod root
+// cause of the M1 download freeze on mobile DPI (2026-06-10).
+func TestBuildVLESSLink_XHTTPExtraEmitted(t *testing.T) {
+	ob := xray.Outbound{
+		Tag:      "xhttp-extra",
+		Protocol: "vless",
+		Settings: vlessOutboundSettings(t),
+		StreamSettings: &xray.StreamSettings{
+			Network:         "xhttp",
+			Security:        "reality",
+			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
+			XHTTPSettings:   xhttpStreamSettings(t, true),
+		},
+	}
+	params := parseLinkParams(t, buildVLESSLink(ob, true))
+	if got := params.Get("mode"); got != "packet-up" {
+		t.Errorf("mode: got %q, want packet-up", got)
+	}
+	ex := params.Get("extra")
+	if ex == "" {
+		t.Fatal("extra param missing — xmux would not reach URI clients")
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(ex), &parsed); err != nil {
+		t.Fatalf("extra is not valid JSON (%q): %v", ex, err)
+	}
+	if _, ok := parsed["xmux"]; !ok {
+		t.Errorf("extra missing xmux: %v", parsed)
+	}
+	if parsed["xPaddingBytes"] != "100-1000" {
+		t.Errorf("extra xPaddingBytes: got %v, want 100-1000", parsed["xPaddingBytes"])
+	}
+}
+
+func TestBuildVLESSLink_XHTTPNoExtraWhenAbsent(t *testing.T) {
+	ob := xray.Outbound{
+		Tag:      "xhttp-noextra",
+		Protocol: "vless",
+		Settings: vlessOutboundSettings(t),
+		StreamSettings: &xray.StreamSettings{
+			Network:         "xhttp",
+			Security:        "reality",
+			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
+			XHTTPSettings:   xhttpStreamSettings(t, false),
+		},
+	}
+	params := parseLinkParams(t, buildVLESSLink(ob, true))
+	if got := params.Get("extra"); got != "" {
+		t.Errorf("extra should be absent when xhttp has no extra, got %q", got)
+	}
+}
+
+// The UA gate: when the client is NOT v2rayN-family (emitXHTTPExtra=false), `extra`
+// must be dropped even if present, so Happ/libXray/sing-box clients keep connecting.
+// The rest of the URI (mode/path/host/reality) stays intact → clean URI still works.
+func TestBuildVLESSLink_XHTTPExtraGatedOff(t *testing.T) {
+	ob := xray.Outbound{
+		Tag:      "xhttp-gated",
+		Protocol: "vless",
+		Settings: vlessOutboundSettings(t),
+		StreamSettings: &xray.StreamSettings{
+			Network:         "xhttp",
+			Security:        "reality",
+			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
+			XHTTPSettings:   xhttpStreamSettings(t, true),
+		},
+	}
+	params := parseLinkParams(t, buildVLESSLink(ob, false))
+	if got := params.Get("extra"); got != "" {
+		t.Errorf("extra must be absent when emitXHTTPExtra=false (Happ/libXray gate), got %q", got)
+	}
+	if got := params.Get("mode"); got != "packet-up" {
+		t.Errorf("mode should still be present on the clean URI, got %q", got)
+	}
+}
+
+func TestClientSupportsXHTTPExtra(t *testing.T) {
+	cases := map[string]bool{
+		"v2rayN/7.22.5":  true,
+		"v2rayNG/1.10.7": true,
+		"V2RayN/7.0":     true, // case-insensitive
+		"Happ/3.23.0":    false,
+		"Streisand":      false,
+		"sing-box 1.10":  false,
+		"Hiddify/2.0":    false,
+		"":               false,
+	}
+	for ua, want := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/sub/x/links.txt", nil)
+		if ua != "" {
+			r.Header.Set("User-Agent", ua)
+		}
+		if got := clientSupportsXHTTPExtra(r); got != want {
+			t.Errorf("UA %q: got %v, want %v", ua, got, want)
+		}
+	}
+	if clientSupportsXHTTPExtra(nil) {
+		t.Error("nil request must not be treated as extra-capable")
 	}
 }
 
@@ -180,7 +307,7 @@ func TestBuildTrojanLink_TLSPCSVCNEmitted(t *testing.T) {
 			},
 		},
 	}
-	link := buildTrojanLink(ob)
+	link := buildTrojanLink(ob, false)
 	params := parseLinkParams(t, link)
 	if got := params.Get("pcs"); got != "FFEE0011" {
 		t.Errorf("pcs: got %q, want %q", got, "FFEE0011")


### PR DESCRIPTION
## Problem
URI-import clients (the majority per access logs — v2rayN, Happ, v2raytun) never received the `xmux` + `xPaddingBytes` anti-volumetric levers: the links generator dropped the xhttp `extra` block, so `vless://` subscriptions carried only host/path/mode. On RU-mobile DPI this leaves sustained downloads exposed to the intermittent volumetric freeze (lab: no-xmux stalled 4/5 vs xmux 5/5 during a wave).

## Change
Emit `extra` (JSON, URL-encoded) in the vless:// URI **gated on User-Agent**:
- **v2rayN / v2rayNG** → get `extra` with xmux (mature XHTTP+xmux support; verified to fix the stall).
- **Everyone else** (Happ/Streisand/INCY = Xray-core-embedded, sing-box, libXray) → clean URI, **no `extra`**.

### Why the gate
Non-v2rayN clients accept and even display the `extra` param but then **fail to connect** — TLS/REALITY handshake completes, no HTTP data flows (XTLS/Xray-core#5918, #6048, open/unreproduced upstream; version-coupling sensitive). sing-box/libXray don't parse it at all (libXray#62). Empirically confirmed: Happ on mobile won't connect with `extra`, connects fine without. So the gate prevents a regression for those clients while delivering xmux where it works.

## Implementation
- New `clientSupportsXHTTPExtra(r)` (UA contains `v2rayn`, case-insensitive → matches v2rayN + v2rayNG).
- `emitXHTTPExtra bool` threaded through `buildVLESSLink` / `buildTrojanLink` / `applyTransportParams` / `buildProxyLinks(Entries)` / `writeProxyLinksText|B64`; handlers compute it from the request.

## Tests
- `TestBuildVLESSLink_XHTTPExtraEmitted` — emit=true → `extra` present with xmux.
- `TestBuildVLESSLink_XHTTPExtraGatedOff` — emit=false → no `extra`, clean URI intact.
- `TestClientSupportsXHTTPExtra` — UA matrix (v2rayN/NG yes; Happ/Streisand/sing-box/Hiddify/empty/nil no).

All gates green locally: `go test -race`, vet, gosec, staticcheck, golangci-lint (0 issues), `go mod tidy`.