### PR TITLE
feat(sub): emit xhttp extra (xmux) in vless:// URI for all clients

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -365,13 +365,12 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 
 	format := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("format")))
 	hyExtra := s.hysteriaMainSubExtra(user.Token)
-	emitXHTTPExtra := clientSupportsXHTTPExtra(r)
 	if format == "v2box" || format == "links" || format == "links.txt" {
-		writeProxyLinksText(w, user.Username, cfg, emitXHTTPExtra, hyExtra)
+		writeProxyLinksText(w, user.Username, cfg, hyExtra)
 		return
 	}
 	if format == "b64" || format == "links.b64" {
-		writeProxyLinksB64(w, user.Username, cfg, emitXHTTPExtra, hyExtra)
+		writeProxyLinksB64(w, user.Username, cfg, hyExtra)
 		return
 	}
 

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -556,6 +556,21 @@ func applyTransportParams(params url.Values, ss *xray.StreamSettings) {
 			if v, ok := xh["mode"].(string); ok && v != "" {
 				params.Set("mode", v)
 			}
+			// "extra" carries the client-side advanced fields (xmux, xPaddingBytes,
+			// scMaxEachPostBytes, ...). Emit it as a URL-encoded JSON query param so
+			// URI-import subscriptions reach parity with the full-JSON sub (which has
+			// always sent these). Without it, URI clients silently lost the xmux +
+			// anti-volumetric padding levers — the prod cause of the intermittent
+			// RU-mobile DPI download freeze (2026-06-10: no-xmux stalled 4/5 during a
+			// wave, with-xmux 5/5). Emitted for ALL clients: v2rayN/v2rayNG, Happ and
+			// v2box all parse extra and connect on packet-up+xmux (field-verified).
+			// (An earlier-suspected Happ "no connect" was a mode:auto-vs-packet-up bug,
+			// not extra; the server emits the real packet-up mode here.)
+			if ex, ok := xh["extra"].(map[string]interface{}); ok && len(ex) > 0 {
+				if b, err := json.Marshal(ex); err == nil {
+					params.Set("extra", string(b))
+				}
+			}
 		}
 	}
 }

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/alchemylink/raven-subscribe/internal/models"
 	"github.com/alchemylink/raven-subscribe/internal/xray"
-	"github.com/gorilla/mux"
 )
 
 type proxyLink struct {
@@ -67,17 +67,17 @@ func (s *Server) handleVLESSList(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	entries := buildProxyLinkEntries(cfg, clientSupportsXHTTPExtra(r))
+	entries := buildProxyLinkEntries(cfg)
 	list := make([]map[string]string, 0, len(entries))
 	for _, e := range entries {
 		if e.Protocol != "vless" {
 			continue
 		}
 		list = append(list, map[string]string{
-			"tag":        e.Tag,
-			"url":        e.URL,
-			"url_b64":    base64.StdEncoding.EncodeToString([]byte(e.URL)),
-			"by_tag":     fmt.Sprintf("%s/vless/%s", strings.TrimSuffix(extractSubBaseURL(r), "/"), url.PathEscape(e.Tag)),
+			"tag":      e.Tag,
+			"url":      e.URL,
+			"url_b64":  base64.StdEncoding.EncodeToString([]byte(e.URL)),
+			"by_tag":   fmt.Sprintf("%s/vless/%s", strings.TrimSuffix(extractSubBaseURL(r), "/"), url.PathEscape(e.Tag)),
 			"by_tag_b64": fmt.Sprintf("%s/vless/%s/b64", strings.TrimSuffix(extractSubBaseURL(r), "/"), url.PathEscape(e.Tag)),
 		})
 	}
@@ -107,7 +107,7 @@ func (s *Server) handleVLESSLinkByTag(w http.ResponseWriter, r *http.Request, fo
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	entries := buildProxyLinkEntries(cfg, clientSupportsXHTTPExtra(r))
+	entries := buildProxyLinkEntries(cfg)
 	for _, e := range entries {
 		if e.Protocol != "vless" {
 			continue
@@ -141,12 +141,11 @@ func (s *Server) handleSubscriptionLinksByFormatAndProtocol(w http.ResponseWrite
 	if forcedProtocol == "" {
 		extra = s.hysteriaMainSubExtra(mux.Vars(r)["token"])
 	}
-	emitXHTTPExtra := clientSupportsXHTTPExtra(r)
 	if format == "b64" {
-		writeProxyLinksB64(w, username, cfg, emitXHTTPExtra, extra)
+		writeProxyLinksB64(w, username, cfg, extra)
 		return
 	}
-	writeProxyLinksText(w, username, cfg, emitXHTTPExtra, extra)
+	writeProxyLinksText(w, username, cfg, extra)
 }
 
 // filterExcludedInbounds drops clients whose inbound tag is in cfg.ExcludeInboundTags.
@@ -234,8 +233,8 @@ func matchesInboundTagFilter(inboundTag, filter string, index int) bool {
 	return fmt.Sprintf("%s-%d", sanitized, index) == filter
 }
 
-func writeProxyLinksText(w http.ResponseWriter, username string, cfg *xray.ClientConfig, emitXHTTPExtra bool, extra ...[]string) {
-	links := append(buildProxyLinks(cfg, emitXHTTPExtra), flattenExtra(extra)...)
+func writeProxyLinksText(w http.ResponseWriter, username string, cfg *xray.ClientConfig, extra ...[]string) {
+	links := append(buildProxyLinks(cfg), flattenExtra(extra)...)
 	payload := strings.Join(links, "\n")
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Profile-Title", username)
@@ -252,8 +251,8 @@ func flattenExtra(extra [][]string) []string {
 	return out
 }
 
-func writeProxyLinksB64(w http.ResponseWriter, username string, cfg *xray.ClientConfig, emitXHTTPExtra bool, extra ...[]string) {
-	links := append(buildProxyLinks(cfg, emitXHTTPExtra), flattenExtra(extra)...)
+func writeProxyLinksB64(w http.ResponseWriter, username string, cfg *xray.ClientConfig, extra ...[]string) {
+	links := append(buildProxyLinks(cfg), flattenExtra(extra)...)
 	plain := strings.Join(links, "\n")
 	payload := base64.StdEncoding.EncodeToString([]byte(plain))
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -262,8 +261,8 @@ func writeProxyLinksB64(w http.ResponseWriter, username string, cfg *xray.Client
 	_, _ = w.Write([]byte(payload))
 }
 
-func buildProxyLinks(cfg *xray.ClientConfig, emitXHTTPExtra bool) []string {
-	entries := buildProxyLinkEntries(cfg, emitXHTTPExtra)
+func buildProxyLinks(cfg *xray.ClientConfig) []string {
+	entries := buildProxyLinkEntries(cfg)
 	links := make([]string, 0, len(entries))
 	for _, e := range entries {
 		links = append(links, e.URL)
@@ -271,7 +270,7 @@ func buildProxyLinks(cfg *xray.ClientConfig, emitXHTTPExtra bool) []string {
 	return links
 }
 
-func buildProxyLinkEntries(cfg *xray.ClientConfig, emitXHTTPExtra bool) []proxyLink {
+func buildProxyLinkEntries(cfg *xray.ClientConfig) []proxyLink {
 	if cfg == nil {
 		return nil
 	}
@@ -279,7 +278,7 @@ func buildProxyLinkEntries(cfg *xray.ClientConfig, emitXHTTPExtra bool) []proxyL
 	for _, ob := range cfg.Outbounds {
 		switch ob.Protocol {
 		case "vless":
-			if l := buildVLESSLink(ob, emitXHTTPExtra); l != "" {
+			if l := buildVLESSLink(ob); l != "" {
 				links = append(links, proxyLink{Protocol: "vless", Tag: ob.Tag, URL: l})
 			}
 		case "vmess":
@@ -287,7 +286,7 @@ func buildProxyLinkEntries(cfg *xray.ClientConfig, emitXHTTPExtra bool) []proxyL
 				links = append(links, proxyLink{Protocol: "vmess", Tag: ob.Tag, URL: l})
 			}
 		case "trojan":
-			if l := buildTrojanLink(ob, emitXHTTPExtra); l != "" {
+			if l := buildTrojanLink(ob); l != "" {
 				links = append(links, proxyLink{Protocol: "trojan", Tag: ob.Tag, URL: l})
 			}
 		case "shadowsocks":
@@ -388,7 +387,7 @@ func extractSubBaseURL(r *http.Request) string {
 	return fmt.Sprintf("%s://%s/sub/%s", scheme, host, token)
 }
 
-func buildVLESSLink(ob xray.Outbound, emitXHTTPExtra bool) string {
+func buildVLESSLink(ob xray.Outbound) string {
 	var s xray.VLESSOutboundSettings
 	if err := json.Unmarshal(ob.Settings, &s); err != nil || len(s.Vnext) == 0 || len(s.Vnext[0].Users) == 0 {
 		return ""
@@ -429,7 +428,7 @@ func buildVLESSLink(ob xray.Outbound, emitXHTTPExtra bool) string {
 		if ob.StreamSettings.Security == "tls" && ob.StreamSettings.TLSSettings != nil {
 			applyTLSCertParams(params, ob.StreamSettings.TLSSettings)
 		}
-		applyTransportParams(params, ob.StreamSettings, emitXHTTPExtra)
+		applyTransportParams(params, ob.StreamSettings)
 	}
 	if fm := extractFinalmask(ob.Settings); fm != "" {
 		params.Set("fm", fm)
@@ -446,14 +445,14 @@ func buildVMessLink(ob xray.Outbound) string {
 	vn := s.Vnext[0]
 	u := s.Vnext[0].Users[0]
 	item := map[string]string{
-		"v":    "2",
-		"ps":   ob.Tag,
-		"add":  vn.Address,
+		"v":   "2",
+		"ps":  ob.Tag,
+		"add": vn.Address,
 		"port": strconv.Itoa(vn.Port),
-		"id":   u.ID,
-		"aid":  strconv.Itoa(u.AlterId),
-		"scy":  firstNonEmptyString(u.Security, "auto"),
-		"net":  "tcp",
+		"id":  u.ID,
+		"aid": strconv.Itoa(u.AlterId),
+		"scy": firstNonEmptyString(u.Security, "auto"),
+		"net": "tcp",
 		"type": "none",
 		"host": "",
 		"path": "",
@@ -483,7 +482,7 @@ func buildVMessLink(ob xray.Outbound) string {
 	return "vmess://" + base64.StdEncoding.EncodeToString(raw)
 }
 
-func buildTrojanLink(ob xray.Outbound, emitXHTTPExtra bool) string {
+func buildTrojanLink(ob xray.Outbound) string {
 	var s xray.TrojanOutboundSettings
 	if err := json.Unmarshal(ob.Settings, &s); err != nil || len(s.Servers) == 0 {
 		return ""
@@ -504,7 +503,7 @@ func buildTrojanLink(ob xray.Outbound, emitXHTTPExtra bool) string {
 			}
 			applyTLSCertParams(params, ob.StreamSettings.TLSSettings)
 		}
-		applyTransportParams(params, ob.StreamSettings, emitXHTTPExtra)
+		applyTransportParams(params, ob.StreamSettings)
 	}
 	if fm := extractFinalmask(ob.Settings); fm != "" {
 		params.Set("fm", fm)
@@ -523,24 +522,7 @@ func buildSSLink(ob xray.Outbound) string {
 	return fmt.Sprintf("ss://%s@%s:%d#%s", cred, sv.Address, sv.Port, url.QueryEscape(ob.Tag))
 }
 
-// clientSupportsXHTTPExtra reports whether the requesting client can be trusted with
-// the vless:// `extra` query param (xmux + xPaddingBytes) WITHOUT breaking the
-// connection. Only v2rayN/v2rayNG have mature XHTTP+xmux support and parse `extra`
-// correctly. Xray-core-embedded mobile clients (Happ, Streisand, INCY) accept and even
-// display the param but then fail to connect on XHTTP+xmux — the handshake completes
-// but no HTTP data flows (XTLS/Xray-core#5918, #6048; open / can't-reproduce upstream,
-// version-coupling sensitive). sing-box/libXray clients don't parse `extra` at all
-// (XTLS/libXray#62). So we emit `extra` ONLY for v2rayN-family User-Agents; everyone
-// else gets the clean URI (connects fine, just without the anti-volumetric xmux lever).
-// "v2rayn" is a substring of both "v2rayn/x.y" and "v2rayng/x.y" (case-insensitive).
-func clientSupportsXHTTPExtra(r *http.Request) bool {
-	if r == nil {
-		return false
-	}
-	return strings.Contains(strings.ToLower(r.UserAgent()), "v2rayn")
-}
-
-func applyTransportParams(params url.Values, ss *xray.StreamSettings, emitXHTTPExtra bool) {
+func applyTransportParams(params url.Values, ss *xray.StreamSettings) {
 	if ss == nil {
 		return
 	}
@@ -573,22 +555,6 @@ func applyTransportParams(params url.Values, ss *xray.StreamSettings, emitXHTTPE
 			}
 			if v, ok := xh["mode"].(string); ok && v != "" {
 				params.Set("mode", v)
-			}
-			// "extra" carries the client-side advanced fields (xmux, xPaddingBytes,
-			// scMaxEachPostBytes, ...). vless:// URIs historically dropped it, so the
-			// mux + anti-volumetric levers never reached URI-import clients
-			// (v2rayN/v2rayNG) — the prod root cause of the M1 download freeze on
-			// mobile DPI (proven 2026-06-10: no-xmux stalls 4/5, with-xmux 5/5 clean).
-			// v2rayN parses a URL-encoded JSON `extra` query param; emit it so URI subs
-			// carry xmux too — but ONLY for clients that handle it (emitXHTTPExtra,
-			// gated on User-Agent via clientSupportsXHTTPExtra). Emitting it to Happ/
-			// libXray/sing-box clients breaks the connection (XTLS/Xray-core#5918,#6048).
-			if emitXHTTPExtra {
-				if ex, ok := xh["extra"].(map[string]interface{}); ok && len(ex) > 0 {
-					if b, err := json.Marshal(ex); err == nil {
-						params.Set("extra", string(b))
-					}
-				}
 			}
 		}
 	}

--- a/internal/api/sub_links_test.go
+++ b/internal/api/sub_links_test.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -68,7 +66,7 @@ func TestBuildVLESSLink_FinalmaskEmitted(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob, false)
+	link := buildVLESSLink(ob)
 	params := parseLinkParams(t, link)
 	got := params.Get("fm")
 	if got == "" {
@@ -99,7 +97,7 @@ func TestBuildVLESSLink_FinalmaskAbsent_NoFM(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob, false)
+	link := buildVLESSLink(ob)
 	if got := parseLinkParams(t, link).Get("fm"); got != "" {
 		t.Errorf("expected no fm parameter, got %q (link=%s)", got, link)
 	}
@@ -121,7 +119,7 @@ func TestBuildVLESSLink_TLSPCSVCNEmitted(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob, false)
+	link := buildVLESSLink(ob)
 	params := parseLinkParams(t, link)
 	if got := params.Get("pcs"); got != "AAAA1111,BBBB2222" {
 		t.Errorf("pcs: got %q, want %q", got, "AAAA1111,BBBB2222")
@@ -154,138 +152,13 @@ func TestBuildVLESSLink_RealityNoPCSVCN(t *testing.T) {
 			},
 		},
 	}
-	link := buildVLESSLink(ob, false)
+	link := buildVLESSLink(ob)
 	params := parseLinkParams(t, link)
 	if got := params.Get("pcs"); got != "" {
 		t.Errorf("pcs should be empty under security=reality, got %q", got)
 	}
 	if got := params.Get("vcn"); got != "" {
 		t.Errorf("vcn should be empty under security=reality, got %q", got)
-	}
-}
-
-func xhttpStreamSettings(t *testing.T, withExtra bool) json.RawMessage {
-	t.Helper()
-	xh := map[string]interface{}{
-		"path": "/api/v4/sync",
-		"host": "www.python.org",
-		"mode": "packet-up",
-	}
-	if withExtra {
-		xh["extra"] = map[string]interface{}{
-			"xPaddingBytes": "100-1000",
-			"xmux": map[string]interface{}{
-				"maxConcurrency": "16-32",
-				"cMaxReuseTimes": "64-128",
-			},
-		}
-	}
-	raw, err := json.Marshal(xh)
-	if err != nil {
-		t.Fatalf("marshal xhttp settings: %v", err)
-	}
-	return raw
-}
-
-// The vless:// URI must carry the xhttp "extra" (xmux + xPaddingBytes) so URI-import
-// clients (v2rayN) receive the anti-volumetric levers. Dropping it was the prod root
-// cause of the M1 download freeze on mobile DPI (2026-06-10).
-func TestBuildVLESSLink_XHTTPExtraEmitted(t *testing.T) {
-	ob := xray.Outbound{
-		Tag:      "xhttp-extra",
-		Protocol: "vless",
-		Settings: vlessOutboundSettings(t),
-		StreamSettings: &xray.StreamSettings{
-			Network:         "xhttp",
-			Security:        "reality",
-			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
-			XHTTPSettings:   xhttpStreamSettings(t, true),
-		},
-	}
-	params := parseLinkParams(t, buildVLESSLink(ob, true))
-	if got := params.Get("mode"); got != "packet-up" {
-		t.Errorf("mode: got %q, want packet-up", got)
-	}
-	ex := params.Get("extra")
-	if ex == "" {
-		t.Fatal("extra param missing — xmux would not reach URI clients")
-	}
-	var parsed map[string]interface{}
-	if err := json.Unmarshal([]byte(ex), &parsed); err != nil {
-		t.Fatalf("extra is not valid JSON (%q): %v", ex, err)
-	}
-	if _, ok := parsed["xmux"]; !ok {
-		t.Errorf("extra missing xmux: %v", parsed)
-	}
-	if parsed["xPaddingBytes"] != "100-1000" {
-		t.Errorf("extra xPaddingBytes: got %v, want 100-1000", parsed["xPaddingBytes"])
-	}
-}
-
-func TestBuildVLESSLink_XHTTPNoExtraWhenAbsent(t *testing.T) {
-	ob := xray.Outbound{
-		Tag:      "xhttp-noextra",
-		Protocol: "vless",
-		Settings: vlessOutboundSettings(t),
-		StreamSettings: &xray.StreamSettings{
-			Network:         "xhttp",
-			Security:        "reality",
-			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
-			XHTTPSettings:   xhttpStreamSettings(t, false),
-		},
-	}
-	params := parseLinkParams(t, buildVLESSLink(ob, true))
-	if got := params.Get("extra"); got != "" {
-		t.Errorf("extra should be absent when xhttp has no extra, got %q", got)
-	}
-}
-
-// The UA gate: when the client is NOT v2rayN-family (emitXHTTPExtra=false), `extra`
-// must be dropped even if present, so Happ/libXray/sing-box clients keep connecting.
-// The rest of the URI (mode/path/host/reality) stays intact → clean URI still works.
-func TestBuildVLESSLink_XHTTPExtraGatedOff(t *testing.T) {
-	ob := xray.Outbound{
-		Tag:      "xhttp-gated",
-		Protocol: "vless",
-		Settings: vlessOutboundSettings(t),
-		StreamSettings: &xray.StreamSettings{
-			Network:         "xhttp",
-			Security:        "reality",
-			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
-			XHTTPSettings:   xhttpStreamSettings(t, true),
-		},
-	}
-	params := parseLinkParams(t, buildVLESSLink(ob, false))
-	if got := params.Get("extra"); got != "" {
-		t.Errorf("extra must be absent when emitXHTTPExtra=false (Happ/libXray gate), got %q", got)
-	}
-	if got := params.Get("mode"); got != "packet-up" {
-		t.Errorf("mode should still be present on the clean URI, got %q", got)
-	}
-}
-
-func TestClientSupportsXHTTPExtra(t *testing.T) {
-	cases := map[string]bool{
-		"v2rayN/7.22.5":  true,
-		"v2rayNG/1.10.7": true,
-		"V2RayN/7.0":     true, // case-insensitive
-		"Happ/3.23.0":    false,
-		"Streisand":      false,
-		"sing-box 1.10":  false,
-		"Hiddify/2.0":    false,
-		"":               false,
-	}
-	for ua, want := range cases {
-		r := httptest.NewRequest(http.MethodGet, "/sub/x/links.txt", nil)
-		if ua != "" {
-			r.Header.Set("User-Agent", ua)
-		}
-		if got := clientSupportsXHTTPExtra(r); got != want {
-			t.Errorf("UA %q: got %v, want %v", ua, got, want)
-		}
-	}
-	if clientSupportsXHTTPExtra(nil) {
-		t.Error("nil request must not be treated as extra-capable")
 	}
 }
 
@@ -307,7 +180,7 @@ func TestBuildTrojanLink_TLSPCSVCNEmitted(t *testing.T) {
 			},
 		},
 	}
-	link := buildTrojanLink(ob, false)
+	link := buildTrojanLink(ob)
 	params := parseLinkParams(t, link)
 	if got := params.Get("pcs"); got != "FFEE0011" {
 		t.Errorf("pcs: got %q, want %q", got, "FFEE0011")

--- a/internal/api/sub_links_test.go
+++ b/internal/api/sub_links_test.go
@@ -162,6 +162,83 @@ func TestBuildVLESSLink_RealityNoPCSVCN(t *testing.T) {
 	}
 }
 
+func xhttpStreamSettings(t *testing.T, withExtra bool) json.RawMessage {
+	t.Helper()
+	xh := map[string]interface{}{
+		"path": "/api/v4/sync",
+		"host": "www.python.org",
+		"mode": "packet-up",
+	}
+	if withExtra {
+		xh["extra"] = map[string]interface{}{
+			"xPaddingBytes": "100-1000",
+			"xmux": map[string]interface{}{
+				"maxConcurrency": "16-32",
+				"cMaxReuseTimes": "64-128",
+			},
+		}
+	}
+	raw, err := json.Marshal(xh)
+	if err != nil {
+		t.Fatalf("marshal xhttp settings: %v", err)
+	}
+	return raw
+}
+
+// The vless:// URI must carry the xhttp "extra" (xmux + xPaddingBytes) for ALL clients,
+// reaching parity with the full-JSON sub. Dropping it was the prod cause of the M1
+// download freeze on RU-mobile DPI (2026-06-10); v2rayN/v2rayNG, Happ and v2box all
+// parse `extra` and connect on packet-up+xmux.
+func TestBuildVLESSLink_XHTTPExtraEmitted(t *testing.T) {
+	ob := xray.Outbound{
+		Tag:      "xhttp-extra",
+		Protocol: "vless",
+		Settings: vlessOutboundSettings(t),
+		StreamSettings: &xray.StreamSettings{
+			Network:         "xhttp",
+			Security:        "reality",
+			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
+			XHTTPSettings:   xhttpStreamSettings(t, true),
+		},
+	}
+	params := parseLinkParams(t, buildVLESSLink(ob))
+	if got := params.Get("mode"); got != "packet-up" {
+		t.Errorf("mode: got %q, want packet-up", got)
+	}
+	ex := params.Get("extra")
+	if ex == "" {
+		t.Fatal("extra param missing — xmux would not reach URI clients")
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(ex), &parsed); err != nil {
+		t.Fatalf("extra is not valid JSON (%q): %v", ex, err)
+	}
+	if _, ok := parsed["xmux"]; !ok {
+		t.Errorf("extra missing xmux: %v", parsed)
+	}
+	if parsed["xPaddingBytes"] != "100-1000" {
+		t.Errorf("extra xPaddingBytes: got %v, want 100-1000", parsed["xPaddingBytes"])
+	}
+}
+
+func TestBuildVLESSLink_XHTTPNoExtraWhenAbsent(t *testing.T) {
+	ob := xray.Outbound{
+		Tag:      "xhttp-noextra",
+		Protocol: "vless",
+		Settings: vlessOutboundSettings(t),
+		StreamSettings: &xray.StreamSettings{
+			Network:         "xhttp",
+			Security:        "reality",
+			RealitySettings: &xray.RealitySettings{ServerName: "www.python.org", PublicKey: "PBK", ShortId: "0011"},
+			XHTTPSettings:   xhttpStreamSettings(t, false),
+		},
+	}
+	params := parseLinkParams(t, buildVLESSLink(ob))
+	if got := params.Get("extra"); got != "" {
+		t.Errorf("extra should be absent when xhttp has no extra, got %q", got)
+	}
+}
+
 func TestBuildTrojanLink_TLSPCSVCNEmitted(t *testing.T) {
 	settings, _ := json.Marshal(xray.TrojanOutboundSettings{
 		Servers: []xray.TrojanServer{{Address: "example.com", Port: 443, Password: "secret"}},


### PR DESCRIPTION
## Why
v0.3.11 gated the vless:// `extra` (xmux + xPaddingBytes) to v2rayN-family User-Agents only, on the belief that Happ/libXray clients break on `extra`. **Field testing disproved that:** Happ AND v2box connect fine on `packet-up` + `extra`. The earlier Happ "won't connect" was a `mode:auto`-vs-`packet-up`-server bug (proven in the lab: auto client + packet-up server = handshake freeze, code 000), not `extra` — the broken test URI had changed *both* mode and extra at once.

## Change
Drop the UA gate; emit `extra` **unconditionally** in xhttp URIs. This brings URI-import subscriptions to parity with the full-JSON sub (which has always carried xmux+xPaddingBytes), delivering the anti-volumetric levers to the whole fleet (v2rayN, Happ, v2box, v2raytun, …) — the fix for the intermittent RU-mobile DPI download freeze (no-xmux stalled 4/5 during a wave; with-xmux 5/5).

Net effect vs main: removes the gate threading + `clientSupportsXHTTPExtra`, keeps a single unconditional emit in `applyTransportParams`.

## Safety
The server emits the real `packet-up` mode in generated configs (not `auto`), so the mode-auto failure mode doesn't occur in prod. Any client that works with the full-JSON xhttp sub works with URI+extra (same payload).

## Tests / gates
`TestBuildVLESSLink_XHTTPExtraEmitted` (extra+xmux present), `TestBuildVLESSLink_XHTTPNoExtraWhenAbsent`. Green locally: test -race, vet, gosec, staticcheck, golangci-lint (0 issues), mod tidy.