### PR TITLE
fix(ci): force check-latest on actions/setup-go to avoid stale-patch govulncheck failures

### DIFF
--- a/.github/actions/setup-go-env/action.yml
+++ b/.github/actions/setup-go-env/action.yml
@@ -17,6 +17,7 @@ runs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ${{ inputs.go-version }}
+        check-latest: true
 
     - name: Cache Go modules
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -60,6 +61,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -87,6 +89,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -58,6 +59,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -91,6 +93,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
+          check-latest: true
 
       - name: Cache Go modules
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## Summary
- `Test` and `Security Scan` are currently failing on `main` since 2026-07-11 with `govulncheck` flagging `GO-2026-5856` (crypto/tls ECH PSK-leak, CVE-2026-42505), fixed in `go1.26.5` (released 2026-07-07).
- Root cause: the `ubuntu-24.04` runner image (built 2026-07-05, before go1.26.5 shipped) has `go1.26.4` pre-baked in its tool cache. `actions/setup-go` with the default `check-latest: false` uses that cached match for our floating `go-version: "1.26"` spec without checking the network for a newer patch — re-running CI doesn't help because it always hits the same stale local cache.
- Fix: add `check-latest: true` to every `actions/setup-go` step (`build.yml`, `security.yml`, and the shared `setup-go-env` composite action used by `test.yml`), so it always resolves the actual latest 1.26.x patch instead of trusting a possibly-outdated runner-image cache.
- No application code changed; `go build ./...` was already clean locally.

## Test plan
- [ ] CI green on this PR (Test + Security Scan `Vulnerability Check` jobs pass against go1.26.5+)
- [ ] Confirm `go-version` still resolves to the latest 1.26.x, not an unrelated major bump