### PR TITLE
feat(multi-node): node topology model + DB tables — Phase 1

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -165,7 +166,68 @@ type Config struct {
 	// No-op when xray_api_addr or fallback_inbound_tags are unset.
 	KillSwitchReconcileInterval int `json:"killswitch_reconcile_interval_seconds,omitempty"`
 
+	// Nodes is the optional multi-node topology. When empty, the service runs
+	// single-node exactly as before: ResolvedNodes() synthesizes one implicit
+	// "local" node from the legacy fields (server_host / xray_api_addr /
+	// api_user_inbound_tag). When set, each entry is a homogeneous Xray node
+	// (same inbound/REALITY shape, differing by public_host:public_port) that
+	// the control plane fans user operations out to. See docs/multi-node-design.md.
+	Nodes []NodeConfig `json:"nodes,omitempty"`
+
 	xrayFilePerm os.FileMode `json:"-"`
+}
+
+// NodeConfig describes a single Xray node in a multi-node topology. Nodes are
+// homogeneous by design (§2 of the design doc): they share inbound/REALITY
+// config and differ only in where clients connect (public_host:public_port)
+// and where the control plane provisions them (api_addr).
+type NodeConfig struct {
+	// Name is the stable node identifier used as the FK in the nodes table.
+	// Must be unique and non-empty across the topology.
+	Name string `json:"name"`
+	// APIAddr is the Xray gRPC HandlerService address (e.g. "10.7.0.1:10085").
+	// For grpc-mode nodes this MUST be a private/WG address unless
+	// AllowPublicGRPC is set (plaintext gRPC over the public internet is a
+	// full-control footgun — see §7). Empty is only valid for the implicit
+	// local node in file-backend mode.
+	APIAddr string `json:"api_addr"`
+	// InboundTag is the inbound clients are provisioned onto on this node.
+	InboundTag string `json:"inbound_tag"`
+	// PublicHost is the host that goes into the client outbound for this node.
+	PublicHost string `json:"public_host"`
+	// PublicPort is the port that goes into the client outbound for this node.
+	PublicPort int `json:"public_port"`
+	// Enabled controls whether the node participates in generation/sync. Nil
+	// means true (a node is in rotation by default). Use IsEnabled().
+	Enabled *bool `json:"enabled,omitempty"`
+	// Deploy configures how config durability is delivered to the node.
+	// Optional; nil means grpc mode. Use DeployMode().
+	Deploy *NodeDeploy `json:"deploy,omitempty"`
+	// AllowPublicGRPC opts a grpc-mode node out of the private-address
+	// requirement. Set only when you have mTLS or another out-of-band guard on
+	// a publicly reachable HandlerService.
+	AllowPublicGRPC bool `json:"allow_public_grpc,omitempty"`
+}
+
+// NodeDeploy configures how a node receives config for durability across
+// restarts (see §8). Only "grpc" is implemented in the first iteration;
+// "ssh_rsync" is reserved.
+type NodeDeploy struct {
+	Mode string `json:"mode,omitempty"` // "grpc" (default) | "ssh_rsync"
+}
+
+// IsEnabled reports whether the node participates in rotation. A nil Enabled
+// pointer defaults to true so operators opt out explicitly, never by omission.
+func (n NodeConfig) IsEnabled() bool {
+	return n.Enabled == nil || *n.Enabled
+}
+
+// DeployMode returns the node's deploy mode, defaulting to "grpc".
+func (n NodeConfig) DeployMode() string {
+	if n.Deploy == nil || strings.TrimSpace(n.Deploy.Mode) == "" {
+		return "grpc"
+	}
+	return strings.TrimSpace(n.Deploy.Mode)
 }
 
 // KillSwitchTags returns the inbound tags the fallback killswitch controls.
@@ -222,10 +284,84 @@ func Load(path string) (*Config, error) {
 	if cfg.BalancerStrategy == "" {
 		return nil, fmt.Errorf("invalid balancer_strategy: must be one of random, roundRobin, leastPing, leastLoad")
 	}
+	if err := validateNodes(cfg.Nodes); err != nil {
+		return nil, fmt.Errorf("nodes: %w", err)
+	}
 	if err := applyXrayFilePerm(cfg); err != nil {
 		return nil, fmt.Errorf("xray_config_file_mode: %w", err)
 	}
 	return cfg, nil
+}
+
+// validateNodes checks an explicitly-configured multi-node topology. It is a
+// no-op for single-node deployments (empty nodes): the implicit local node
+// synthesized by ResolvedNodes mirrors already-validated legacy fields and is
+// not subject to these checks.
+func validateNodes(nodes []NodeConfig) error {
+	seen := make(map[string]bool, len(nodes))
+	for i, n := range nodes {
+		name := strings.TrimSpace(n.Name)
+		if name == "" {
+			return fmt.Errorf("node[%d]: name is required", i)
+		}
+		if seen[name] {
+			return fmt.Errorf("node %q: duplicate name", name)
+		}
+		seen[name] = true
+
+		if strings.TrimSpace(n.APIAddr) == "" {
+			return fmt.Errorf("node %q: api_addr is required", name)
+		}
+		mode := n.DeployMode()
+		if mode != "grpc" && mode != "ssh_rsync" {
+			return fmt.Errorf("node %q: invalid deploy.mode %q (want grpc|ssh_rsync)", name, mode)
+		}
+		// Anti-footgun (§7): plaintext gRPC HandlerService grants full control
+		// over users/inbounds. Refuse a public api_addr in grpc mode unless the
+		// operator explicitly accepts the risk (they should be fronting it with
+		// mTLS or another guard).
+		if mode == "grpc" && !n.AllowPublicGRPC && !isPrivateHostPort(n.APIAddr) {
+			return fmt.Errorf("node %q: api_addr %q is not a private/loopback address; "+
+				"bind Xray's gRPC to a WireGuard/private address, or set allow_public_grpc:true "+
+				"if you guard it with mTLS", name, n.APIAddr)
+		}
+	}
+	return nil
+}
+
+// isPrivateHostPort reports whether host:port's host is a loopback or private
+// (RFC1918 / RFC4193 ULA / link-local) IP. A hostname that does not parse as an
+// IP is treated as non-private (conservative: force the operator to be explicit).
+func isPrivateHostPort(addr string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(addr))
+	if err != nil {
+		host = strings.TrimSpace(addr) // tolerate a bare host with no port
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
+
+// ResolvedNodes returns the effective node list. When nodes are configured it
+// returns them verbatim; otherwise it synthesizes a single implicit "local"
+// node from the legacy single-node fields so downstream code can always work
+// with a []NodeConfig (single-node is just N=1). The synthesized node's
+// PublicPort is a placeholder (443) — single-node generation still resolves
+// per-inbound host/port via HostForInbound/InboundPorts until Phase 3 wires
+// per-node outbounds.
+func (c *Config) ResolvedNodes() []NodeConfig {
+	if len(c.Nodes) > 0 {
+		return c.Nodes
+	}
+	return []NodeConfig{{
+		Name:       "local",
+		APIAddr:    c.XrayAPIAddr,
+		InboundTag: c.APIUserInboundTag,
+		PublicHost: c.ServerHost,
+		PublicPort: 443,
+	}}
 }
 
 // normalizeVLESSClientEncryption trims map keys and values so lookups match Xray inbound tags

--- a/internal/config/config_nodes_test.go
+++ b/internal/config/config_nodes_test.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestResolvedNodes_ImplicitLocalWhenEmpty(t *testing.T) {
+	cfg := &Config{
+		ServerHost:        "eu.example.com",
+		XrayAPIAddr:       "127.0.0.1:10085",
+		APIUserInboundTag: "vless-reality-in",
+	}
+	nodes := cfg.ResolvedNodes()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 implicit node, got %d", len(nodes))
+	}
+	n := nodes[0]
+	if n.Name != "local" {
+		t.Errorf("implicit node name: got %q, want local", n.Name)
+	}
+	if n.APIAddr != "127.0.0.1:10085" {
+		t.Errorf("APIAddr: got %q", n.APIAddr)
+	}
+	if n.InboundTag != "vless-reality-in" {
+		t.Errorf("InboundTag: got %q", n.InboundTag)
+	}
+	if n.PublicHost != "eu.example.com" {
+		t.Errorf("PublicHost: got %q", n.PublicHost)
+	}
+	if !n.IsEnabled() {
+		t.Error("implicit node should be enabled")
+	}
+	if n.DeployMode() != "grpc" {
+		t.Errorf("DeployMode default: got %q, want grpc", n.DeployMode())
+	}
+}
+
+func TestResolvedNodes_ExplicitPassthrough(t *testing.T) {
+	cfg := &Config{
+		ServerHost: "eu.example.com",
+		Nodes: []NodeConfig{
+			{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-reality-in", PublicHost: "eu1.example.com", PublicPort: 443},
+			{Name: "eu-2", APIAddr: "10.7.0.2:10085", InboundTag: "vless-reality-in", PublicHost: "eu2.example.com", PublicPort: 443, Enabled: boolPtr(false)},
+		},
+	}
+	nodes := cfg.ResolvedNodes()
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].Name != "eu-1" || nodes[1].Name != "eu-2" {
+		t.Errorf("unexpected node names: %q, %q", nodes[0].Name, nodes[1].Name)
+	}
+	if !nodes[0].IsEnabled() {
+		t.Error("eu-1 should be enabled")
+	}
+	if nodes[1].IsEnabled() {
+		t.Error("eu-2 explicitly disabled should not be enabled")
+	}
+}
+
+func TestValidateNodes(t *testing.T) {
+	cases := []struct {
+		name    string
+		nodes   []NodeConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty is single-node, valid",
+			nodes:   nil,
+			wantErr: false,
+		},
+		{
+			name:    "private grpc ok",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "10.7.0.1:10085"}},
+			wantErr: false,
+		},
+		{
+			name:    "loopback grpc ok",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "127.0.0.1:10085"}},
+			wantErr: false,
+		},
+		{
+			name:    "empty name rejected",
+			nodes:   []NodeConfig{{Name: "", APIAddr: "10.7.0.1:10085"}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate name rejected",
+			nodes: []NodeConfig{
+				{Name: "eu-1", APIAddr: "10.7.0.1:10085"},
+				{Name: "eu-1", APIAddr: "10.7.0.2:10085"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty api_addr rejected",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: ""}},
+			wantErr: true,
+		},
+		{
+			name:    "public grpc without flag rejected",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "203.0.113.5:10085"}},
+			wantErr: true,
+		},
+		{
+			name:    "public grpc with allow flag ok",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "203.0.113.5:10085", AllowPublicGRPC: true}},
+			wantErr: false,
+		},
+		{
+			name:    "invalid deploy mode rejected",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "10.7.0.1:10085", Deploy: &NodeDeploy{Mode: "carrier-pigeon"}}},
+			wantErr: true,
+		},
+		{
+			name:    "public addr with ssh_rsync mode ok (no grpc footgun)",
+			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "203.0.113.5:22", Deploy: &NodeDeploy{Mode: "ssh_rsync"}}},
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNodes(tc.nodes)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_RejectsInvalidNodes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	// Public grpc api_addr without allow_public_grpc must fail at load.
+	body := `{"server_host":"eu.example.com","nodes":[{"name":"eu-1","api_addr":"203.0.113.5:10085","inbound_tag":"vless-reality-in","public_host":"eu1.example.com","public_port":443}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected Load to reject public grpc node, got nil error")
+	}
+}
+
+func TestLoad_AcceptsValidNodes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	body := `{"server_host":"eu.example.com","nodes":[{"name":"eu-1","api_addr":"10.7.0.1:10085","inbound_tag":"vless-reality-in","public_host":"eu1.example.com","public_port":443}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Nodes) != 1 || cfg.Nodes[0].Name != "eu-1" {
+		t.Errorf("nodes not parsed: %+v", cfg.Nodes)
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -104,6 +104,30 @@ func (db *DB) migrate() error {
 		created_at   DATETIME NOT NULL,
 		updated_at   DATETIME NOT NULL
 	);
+
+	-- Multi-node topology (docs/multi-node-design.md §5). Additive: a
+	-- single-node deployment gets exactly one row ('local') and every user
+	-- placed on it via the startup backfill, so behaviour is unchanged.
+	CREATE TABLE IF NOT EXISTS nodes (
+		id          INTEGER PRIMARY KEY AUTOINCREMENT,
+		name        TEXT    NOT NULL UNIQUE,
+		api_addr    TEXT    NOT NULL DEFAULT '',
+		inbound_tag TEXT    NOT NULL DEFAULT '',
+		public_host TEXT    NOT NULL DEFAULT '',
+		public_port INTEGER NOT NULL DEFAULT 0,
+		enabled     INTEGER NOT NULL DEFAULT 1,
+		created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+	-- Which users are placed on which node. Absence of a row = user is NOT on
+	-- that node. Credentials stay per-inbound in user_clients (nodes are
+	-- homogeneous), so this table governs placement only.
+	CREATE TABLE IF NOT EXISTS user_nodes (
+		user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		node_id INTEGER NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+		PRIMARY KEY (user_id, node_id)
+	);
+	CREATE INDEX IF NOT EXISTS idx_user_nodes_node ON user_nodes(node_id);
 	`
 	_, err := db.conn.Exec(schema)
 	if err != nil {
@@ -936,6 +960,151 @@ func (db *DB) ActivateEmergency(profileID int64) error {
 func (db *DB) DeactivateEmergency() error {
 	_, err := db.conn.Exec(`DELETE FROM app_settings WHERE key IN ('emergency_active', 'emergency_profile_id', 'emergency_activated_at')`)
 	return err
+}
+
+// ─── Nodes (multi-node topology) ──────────────────────────────────────────────
+
+// UpsertNode inserts a node or updates the mutable columns of an existing one,
+// keyed by name. created_at is preserved on update. Returns the node id.
+func (db *DB) UpsertNode(n models.Node) (int64, error) {
+	_, err := db.conn.Exec(
+		`INSERT INTO nodes (name, api_addr, inbound_tag, public_host, public_port, enabled)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(name) DO UPDATE SET
+		     api_addr    = excluded.api_addr,
+		     inbound_tag = excluded.inbound_tag,
+		     public_host = excluded.public_host,
+		     public_port = excluded.public_port,
+		     enabled     = excluded.enabled`,
+		n.Name, n.APIAddr, n.InboundTag, n.PublicHost, n.PublicPort, boolInt(n.Enabled),
+	)
+	if err != nil {
+		return 0, err
+	}
+	var id int64
+	if err := db.conn.QueryRow(`SELECT id FROM nodes WHERE name = ?`, n.Name).Scan(&id); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// ListNodes returns all nodes ordered by name.
+func (db *DB) ListNodes() ([]models.Node, error) {
+	rows, err := db.conn.Query(
+		`SELECT id, name, api_addr, inbound_tag, public_host, public_port, enabled, created_at
+		 FROM nodes ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var nodes []models.Node
+	for rows.Next() {
+		var n models.Node
+		var enabled int
+		if err := rows.Scan(&n.ID, &n.Name, &n.APIAddr, &n.InboundTag, &n.PublicHost, &n.PublicPort, &enabled, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		n.Enabled = enabled != 0
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// GetNodeByName returns the node with the given name, or (nil, nil) if absent.
+func (db *DB) GetNodeByName(name string) (*models.Node, error) {
+	var n models.Node
+	var enabled int
+	err := db.conn.QueryRow(
+		`SELECT id, name, api_addr, inbound_tag, public_host, public_port, enabled, created_at
+		 FROM nodes WHERE name = ?`, name,
+	).Scan(&n.ID, &n.Name, &n.APIAddr, &n.InboundTag, &n.PublicHost, &n.PublicPort, &enabled, &n.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	n.Enabled = enabled != 0
+	return &n, nil
+}
+
+// ReconcileNodes makes the nodes table match the desired topology from config.
+// Desired nodes are upserted by name; existing nodes whose name is not in the
+// desired set are marked enabled=0 (never deleted, so user_nodes FKs survive a
+// node being temporarily removed from config). Config is the source of truth
+// for node rows.
+func (db *DB) ReconcileNodes(desired []models.Node) error {
+	keep := make(map[string]bool, len(desired))
+	for _, n := range desired {
+		if _, err := db.UpsertNode(n); err != nil {
+			return fmt.Errorf("upsert node %q: %w", n.Name, err)
+		}
+		keep[n.Name] = true
+	}
+
+	existing, err := db.ListNodes()
+	if err != nil {
+		return err
+	}
+	for _, n := range existing {
+		if keep[n.Name] || !n.Enabled {
+			continue
+		}
+		if _, err := db.conn.Exec(`UPDATE nodes SET enabled = 0 WHERE id = ?`, n.ID); err != nil {
+			return fmt.Errorf("disable vanished node %q: %w", n.Name, err)
+		}
+	}
+	return nil
+}
+
+// BackfillUserNodesToEnabled places every user that currently has no node
+// assignment onto all enabled nodes. This is the Phase-1 migration step that
+// keeps existing users working: on a single-node deployment it assigns everyone
+// to the sole "local" node. It is idempotent — users that already have any
+// placement are left untouched (so explicit per-user placement is never
+// overwritten), and the INSERT OR IGNORE guards the composite PK.
+func (db *DB) BackfillUserNodesToEnabled() error {
+	_, err := db.conn.Exec(
+		`INSERT OR IGNORE INTO user_nodes (user_id, node_id)
+		 SELECT u.id, n.id
+		 FROM users u
+		 CROSS JOIN nodes n
+		 WHERE n.enabled = 1
+		   AND NOT EXISTS (SELECT 1 FROM user_nodes un WHERE un.user_id = u.id)`)
+	return err
+}
+
+// AssignUserToNodes places a user on the given nodes (idempotent). Absence of a
+// row means the user is not on that node; this only adds placements.
+func (db *DB) AssignUserToNodes(userID int64, nodeIDs []int64) error {
+	for _, nid := range nodeIDs {
+		if _, err := db.conn.Exec(
+			`INSERT OR IGNORE INTO user_nodes (user_id, node_id) VALUES (?, ?)`, userID, nid,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListNodeIDsForUser returns the node ids a user is placed on.
+func (db *DB) ListNodeIDsForUser(userID int64) ([]int64, error) {
+	rows, err := db.conn.Query(`SELECT node_id FROM user_nodes WHERE user_id = ? ORDER BY node_id`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/internal/database/nodes_test.go
+++ b/internal/database/nodes_test.go
@@ -1,0 +1,208 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/alchemylink/raven-subscribe/internal/models"
+)
+
+func TestUpsertNode_InsertThenUpdate(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	id, err := db.UpsertNode(models.Node{
+		Name: "local", APIAddr: "127.0.0.1:10085", InboundTag: "vless-reality-in",
+		PublicHost: "eu.example.com", PublicPort: 443, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("UpsertNode insert: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive id, got %d", id)
+	}
+
+	// Update in place by name; id must be stable.
+	id2, err := db.UpsertNode(models.Node{
+		Name: "local", APIAddr: "10.7.0.1:10085", InboundTag: "vless-reality-in",
+		PublicHost: "eu-new.example.com", PublicPort: 8443, Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("UpsertNode update: %v", err)
+	}
+	if id2 != id {
+		t.Errorf("upsert changed id: got %d, want %d", id2, id)
+	}
+
+	got, err := db.GetNodeByName("local")
+	if err != nil {
+		t.Fatalf("GetNodeByName: %v", err)
+	}
+	if got == nil {
+		t.Fatal("node not found after upsert")
+	}
+	if got.APIAddr != "10.7.0.1:10085" || got.PublicHost != "eu-new.example.com" || got.PublicPort != 8443 {
+		t.Errorf("update did not apply: %+v", got)
+	}
+	if got.Enabled {
+		t.Error("node should be disabled after update")
+	}
+}
+
+func TestGetNodeByName_Absent(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	got, err := db.GetNodeByName("nope")
+	if err != nil {
+		t.Fatalf("GetNodeByName: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for absent node, got %+v", got)
+	}
+}
+
+func TestReconcileNodes_DisablesVanished(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	// Initial topology: two enabled nodes.
+	if err := db.ReconcileNodes([]models.Node{
+		{Name: "eu-1", APIAddr: "10.7.0.1:10085", Enabled: true},
+		{Name: "eu-2", APIAddr: "10.7.0.2:10085", Enabled: true},
+	}); err != nil {
+		t.Fatalf("ReconcileNodes initial: %v", err)
+	}
+
+	// eu-2 drops out of config → should be disabled, not deleted.
+	if err := db.ReconcileNodes([]models.Node{
+		{Name: "eu-1", APIAddr: "10.7.0.1:10085", Enabled: true},
+	}); err != nil {
+		t.Fatalf("ReconcileNodes reduced: %v", err)
+	}
+
+	all, err := db.ListNodes()
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 nodes (vanished kept, disabled), got %d", len(all))
+	}
+	byName := map[string]models.Node{}
+	for _, n := range all {
+		byName[n.Name] = n
+	}
+	if !byName["eu-1"].Enabled {
+		t.Error("eu-1 should remain enabled")
+	}
+	if byName["eu-2"].Enabled {
+		t.Error("eu-2 should be disabled after vanishing from config")
+	}
+}
+
+func TestBackfillUserNodesToEnabled(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	// Two users, one enabled + one disabled node.
+	u1, err := db.CreateUser("alice", "", "tok-alice", "")
+	if err != nil {
+		t.Fatalf("CreateUser alice: %v", err)
+	}
+	u2, err := db.CreateUser("bob", "", "tok-bob", "")
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+	localID, err := db.UpsertNode(models.Node{Name: "local", APIAddr: "127.0.0.1:10085", Enabled: true})
+	if err != nil {
+		t.Fatalf("UpsertNode local: %v", err)
+	}
+	if _, err := db.UpsertNode(models.Node{Name: "eu-2", APIAddr: "10.7.0.2:10085", Enabled: false}); err != nil {
+		t.Fatalf("UpsertNode eu-2: %v", err)
+	}
+
+	if err := db.BackfillUserNodesToEnabled(); err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+
+	// Both users placed on the enabled node only.
+	for _, u := range []int64{u1.ID, u2.ID} {
+		ids, err := db.ListNodeIDsForUser(u)
+		if err != nil {
+			t.Fatalf("ListNodeIDsForUser(%d): %v", u, err)
+		}
+		if len(ids) != 1 || ids[0] != localID {
+			t.Errorf("user %d: got node ids %v, want [%d]", u, ids, localID)
+		}
+	}
+}
+
+func TestBackfill_Idempotent_SkipsAlreadyPlaced(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	u, err := db.CreateUser("carol", "", "tok-carol", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	aID, err := db.UpsertNode(models.Node{Name: "a", APIAddr: "10.7.0.1:10085", Enabled: true})
+	if err != nil {
+		t.Fatalf("UpsertNode a: %v", err)
+	}
+	// Explicitly place carol on node a only.
+	if err := db.AssignUserToNodes(u.ID, []int64{aID}); err != nil {
+		t.Fatalf("AssignUserToNodes: %v", err)
+	}
+
+	// A new enabled node appears. Backfill must NOT touch carol (already placed),
+	// preserving explicit per-user placement.
+	if _, err := db.UpsertNode(models.Node{Name: "b", APIAddr: "10.7.0.2:10085", Enabled: true}); err != nil {
+		t.Fatalf("UpsertNode b: %v", err)
+	}
+	if err := db.BackfillUserNodesToEnabled(); err != nil {
+		t.Fatalf("Backfill: %v", err)
+	}
+
+	ids, err := db.ListNodeIDsForUser(u.ID)
+	if err != nil {
+		t.Fatalf("ListNodeIDsForUser: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != aID {
+		t.Errorf("backfill should not have added node b to an already-placed user: got %v, want [%d]", ids, aID)
+	}
+
+	// Running backfill again is a no-op.
+	if err := db.BackfillUserNodesToEnabled(); err != nil {
+		t.Fatalf("Backfill 2: %v", err)
+	}
+	ids2, _ := db.ListNodeIDsForUser(u.ID)
+	if len(ids2) != 1 {
+		t.Errorf("second backfill changed placement: got %v", ids2)
+	}
+}
+
+func TestUserNodes_CascadeOnUserDelete(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	u, err := db.CreateUser("dave", "", "tok-dave", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	nID, err := db.UpsertNode(models.Node{Name: "local", APIAddr: "127.0.0.1:10085", Enabled: true})
+	if err != nil {
+		t.Fatalf("UpsertNode: %v", err)
+	}
+	if err := db.AssignUserToNodes(u.ID, []int64{nID}); err != nil {
+		t.Fatalf("AssignUserToNodes: %v", err)
+	}
+	if err := db.DeleteUser(u.ID); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+	ids, err := db.ListNodeIDsForUser(u.ID)
+	if err != nil {
+		t.Fatalf("ListNodeIDsForUser: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("user_nodes should cascade-delete with user, got %v", ids)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -46,6 +46,20 @@ type Inbound struct {
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
+// Node is a single Xray node in a multi-node topology (the nodes table). It
+// mirrors the DB row; deploy/allow_public_grpc are config-only provisioning
+// concerns and deliberately not stored here. See docs/multi-node-design.md §5.
+type Node struct {
+	ID         int64     `json:"id"`
+	Name       string    `json:"name"`
+	APIAddr    string    `json:"api_addr"`
+	InboundTag string    `json:"inbound_tag"`
+	PublicHost string    `json:"public_host"`
+	PublicPort int       `json:"public_port"`
+	Enabled    bool      `json:"enabled"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
 // UserClient maps a user to their credentials in a specific inbound
 type UserClient struct {
 	ID           int64  `json:"id"`

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alchemylink/raven-subscribe/internal/api"
 	"github.com/alchemylink/raven-subscribe/internal/config"
 	"github.com/alchemylink/raven-subscribe/internal/database"
+	"github.com/alchemylink/raven-subscribe/internal/models"
 	"github.com/alchemylink/raven-subscribe/internal/syncer"
 )
 
@@ -42,6 +43,15 @@ func main() {
 		}
 	}()
 	log.Printf("Database: %s", cfg.DBPath)
+
+	// ── Multi-node topology (Phase 1) ─────────────────────────────────────────
+	// Reconcile the configured nodes into the DB and place any unplaced users on
+	// the enabled nodes. Single-node deployments get one implicit "local" node
+	// and every user on it — behaviour unchanged, data ready for later phases.
+	// Non-fatal: nothing downstream consumes node placement yet.
+	if err := reconcileNodes(cfg, db); err != nil {
+		log.Printf("Node reconcile warning: %v", err)
+	}
 
 	// ── Syncer ──────────────────────────────────────────────────────────────
 	sync := syncer.New(cfg, db)
@@ -138,4 +148,28 @@ func main() {
 		}
 	}
 	log.Println("Stopped")
+}
+
+// reconcileNodes syncs the resolved node topology from config into the DB and
+// backfills user placement. It maps config.NodeConfig (which also carries
+// provisioning-only fields like deploy/allow_public_grpc) down to the DB's
+// models.Node, reconciles by name, then places any unplaced users on the
+// enabled nodes. See docs/multi-node-design.md §5.
+func reconcileNodes(cfg *config.Config, db *database.DB) error {
+	resolved := cfg.ResolvedNodes()
+	desired := make([]models.Node, 0, len(resolved))
+	for _, n := range resolved {
+		desired = append(desired, models.Node{
+			Name:       n.Name,
+			APIAddr:    n.APIAddr,
+			InboundTag: n.InboundTag,
+			PublicHost: n.PublicHost,
+			PublicPort: n.PublicPort,
+			Enabled:    n.IsEnabled(),
+		})
+	}
+	if err := db.ReconcileNodes(desired); err != nil {
+		return err
+	}
+	return db.BackfillUserNodesToEnabled()
 }


### PR DESCRIPTION
Part of the multi-node design (#100). **Phase 1** of the phased migration in `docs/multi-node-design.md` §5/§9 — additive data model only, **no downstream consumer yet**, single-node behavior unchanged.

## What's in
- **config** — `NodeConfig`/`NodeDeploy` structs + optional `nodes` field. `ResolvedNodes()` synthesizes one implicit `"local"` node from the legacy `server_host`/`xray_api_addr`/`api_user_inbound_tag` fields when `nodes` is empty, so downstream can always work with a `[]NodeConfig` (single-node = N=1). `Load()` validates explicit nodes: unique non-empty name, non-empty `api_addr`, and the §7 **anti-footgun** — a grpc-mode node with a non-private `api_addr` is rejected unless `allow_public_grpc:true` (plaintext HandlerService over the public internet = full node control).
- **db** — `nodes` + `user_nodes` tables via `CREATE TABLE IF NOT EXISTS` (matching this repo's existing `migrate()` convention — Raven-subscribe does **not** use goose; that's the dashboard). `models.Node` mirrors the row. Methods: `UpsertNode` (by name), `ListNodes`, `GetNodeByName`, `ReconcileNodes` (upsert desired + disable vanished, **never delete** so `user_nodes` FKs survive), `AssignUserToNodes`, `ListNodeIDsForUser`, `BackfillUserNodesToEnabled` (places zero-placement users on all enabled nodes; idempotent; preserves explicit placement).
- **main** — `reconcileNodes()` at startup: reconciles config nodes into the DB and backfills placement. On a single-node deploy this creates the `local` node and puts every user on it. Non-fatal on error.

## Design notes
- `user_clients` stays **per-inbound**, not per-node — nodes are homogeneous (§2), so one credential is valid on every node with that `inbound_tag`. `user_nodes` governs **placement only**, keeping the migration small.
- **Byte-identical subscriptions**: nothing reads `nodes`/`user_nodes` until Phase 3, so `/sub`/`/c` output is unchanged. This PR only lands the model + backfill so the data is ready.
- Backfill rule = "zero-placement user → all enabled nodes." Single-node case is exactly "all users → local"; already-placed users are skipped (opt-in preserved for Phase 2's per-user placement API).

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race -count=1` — all green
- [x] `golangci-lint`, `staticcheck`, `gosec`, `go mod tidy` — 0 issues / no diff
- [x] New tests: implicit-local synthesis, explicit passthrough, all validation cases (dup name / empty api_addr / public-grpc-without-flag / bad deploy mode / ssh_rsync public ok); DB upsert insert+update, ReconcileNodes disables vanished, backfill assigns + idempotent + skips-placed, user_nodes cascade on user delete