### PR TITLE
feat(multi-node): fan writes out to all nodes — Phase 2

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -57,13 +57,33 @@ type Server struct {
 
 // NewServer creates a new Server with the given config, database, and syncer.
 func NewServer(cfg *config.Config, db *database.DB, syncer Syncer) *Server {
-	var admin core.AdminAPI
-	if apiAddr := strings.TrimSpace(cfg.XrayAPIAddr); apiAddr != "" {
-		admin = xray.NewGRPCAdmin(apiAddr, cfg.ConfigDir, cfg.XrayConfigFilePerm())
-	} else {
-		admin = xray.NewFileAdmin(cfg.ConfigDir, cfg.XrayConfigFilePerm())
+	return &Server{cfg: cfg, db: db, syncer: syncer, admin: buildAdmin(cfg)}
+}
+
+// buildAdmin selects the engine write backend:
+//   - multi-node (nodes configured): fan every mutation out to all enabled
+//     nodes over grpc (empty configDir per node — remote nodes have no local
+//     config.d; durability is the per-node reconcile loop, not a file mirror).
+//   - single-node (no nodes): the legacy path, byte-identical to before —
+//     grpc-with-config-mirror when xray_api_addr is set, else file-backed.
+func buildAdmin(cfg *config.Config) core.AdminAPI {
+	if len(cfg.Nodes) > 0 {
+		var targets []xray.NamedAdmin
+		for _, n := range cfg.Nodes {
+			if !n.IsEnabled() {
+				continue
+			}
+			targets = append(targets, xray.NamedAdmin{
+				Name:  n.Name,
+				Admin: xray.NewGRPCAdmin(n.APIAddr, "", cfg.XrayConfigFilePerm()),
+			})
+		}
+		return xray.NewFanoutAdmin(targets)
 	}
-	return &Server{cfg: cfg, db: db, syncer: syncer, admin: admin}
+	if apiAddr := strings.TrimSpace(cfg.XrayAPIAddr); apiAddr != "" {
+		return xray.NewGRPCAdmin(apiAddr, cfg.ConfigDir, cfg.XrayConfigFilePerm())
+	}
+	return xray.NewFileAdmin(cfg.ConfigDir, cfg.XrayConfigFilePerm())
 }
 
 // Router builds and returns the configured HTTP router.

--- a/internal/xray/fanout.go
+++ b/internal/xray/fanout.go
@@ -1,0 +1,195 @@
+package xray
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/alchemylink/raven-subscribe/internal/core"
+)
+
+// NamedAdmin pairs a node name with the core.AdminAPI that mutates that node.
+// The name is used only for diagnostics (per-node warnings on partial failure).
+type NamedAdmin struct {
+	Name  string
+	Admin core.AdminAPI
+}
+
+// fanoutAdmin implements core.AdminAPI by applying every mutation to a set of
+// nodes (multi-node topology). It hides behind the same interface as a single
+// admin, so api.Server can't tell one node from N (docs/multi-node-design.md §6.1).
+//
+// Failure policy (§6.4): partial failures are NOT rolled back — a user created
+// on the reachable node stays created — and are surfaced via per-node warnings.
+//   - additive ops (AddClient/AddExistingClient/AddInboundFromJSON) succeed when
+//     at least one node applied them; an "already exists" reply counts as applied.
+//   - removals (RemoveClient/RemoveInbound) treat "not found" as already-done and
+//     return the joined real errors from nodes that could not confirm removal, so
+//     a down node stays visible (it gets reconciled once it returns — §6.4/§13).
+type fanoutAdmin struct {
+	targets []NamedAdmin
+}
+
+var _ core.AdminAPI = (*fanoutAdmin)(nil)
+
+// NewFanoutAdmin returns a core.AdminAPI that fans every operation out to all
+// targets. Targets are the enabled nodes of the topology; each is typically a
+// grpc-only per-node admin (NewGRPCAdmin with an empty configDir).
+func NewFanoutAdmin(targets []NamedAdmin) core.AdminAPI {
+	return &fanoutAdmin{targets: targets}
+}
+
+// isBenignExists reports whether err is Xray's idempotent "already exists"
+// reply (AddUser/AddInbound on something already present). Mirrors the idiom in
+// api/fallback.go.
+func isBenignExists(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "exist")
+}
+
+// isBenignAbsent reports whether err is Xray's "already absent" reply
+// (RemoveUser/RemoveInbound on something not present). xray-core surfaces this
+// via several idioms depending on the dispatch path.
+func isBenignAbsent(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "not found") ||
+		strings.Contains(lower, "no such") ||
+		strings.Contains(lower, "not enough information")
+}
+
+// AddClient fans a new-client add out to every node and returns one stored
+// credential JSON to persist. Because nodes are homogeneous the credential is
+// identical on every node; the first success wins and any divergent success is
+// logged loudly as cross-node config drift. Succeeds if at least one node
+// accepted the client; errors only if all nodes failed.
+func (f *fanoutAdmin) AddClient(inboundTag, identity string, hint core.AddClientHint) (string, error) {
+	var stored string
+	var haveStored bool
+	var failures []string
+	okCount := 0
+
+	for _, t := range f.targets {
+		got, err := t.Admin.AddClient(inboundTag, identity, hint)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", t.Name, err))
+			continue
+		}
+		okCount++
+		switch {
+		case !haveStored:
+			stored, haveStored = got, true
+		case got != stored:
+			log.Printf("WARN fanout AddClient %s@%s: node %q returned a different stored config than %q — cross-node config drift",
+				identity, inboundTag, t.Name, f.targets[0].Name)
+		}
+	}
+
+	logFanoutFailures("AddClient", inboundTag, identity, okCount, failures)
+	if okCount == 0 {
+		return "", fmt.Errorf("AddClient %s@%s failed on all %d nodes: %s", identity, inboundTag, len(f.targets), strings.Join(failures, "; "))
+	}
+	return stored, nil
+}
+
+// AddExistingClient re-adds a stored client to every node. "Already exists" is
+// benign (the client is already present). Succeeds if at least one node has the
+// client afterwards.
+func (f *fanoutAdmin) AddExistingClient(inboundTag, identity, storedConfigJSON string) error {
+	var failures []string
+	okCount := 0
+	for _, t := range f.targets {
+		err := t.Admin.AddExistingClient(inboundTag, identity, storedConfigJSON)
+		if err == nil || isBenignExists(err) {
+			okCount++
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%s: %v", t.Name, err))
+	}
+	logFanoutFailures("AddExistingClient", inboundTag, identity, okCount, failures)
+	if okCount == 0 {
+		return fmt.Errorf("AddExistingClient %s@%s failed on all %d nodes: %s", identity, inboundTag, len(f.targets), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// RemoveClient removes a client from every node. "Not found" is benign (already
+// gone). Returns the joined real errors from nodes that could not confirm the
+// removal so the failure stays visible; a down node is reconciled once it
+// returns (§6.4). The caller proceeds with the DB delete regardless.
+func (f *fanoutAdmin) RemoveClient(inboundTag, identity string) error {
+	var failures []string
+	for _, t := range f.targets {
+		err := t.Admin.RemoveClient(inboundTag, identity)
+		if err == nil || isBenignAbsent(err) {
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%s: %v", t.Name, err))
+	}
+	if len(failures) > 0 {
+		log.Printf("WARN fanout RemoveClient %s@%s: %d/%d nodes failed: %s",
+			identity, inboundTag, len(failures), len(f.targets), strings.Join(failures, "; "))
+		return fmt.Errorf("RemoveClient %s@%s failed on %d node(s): %s", identity, inboundTag, len(failures), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// AddInboundFromJSON brings an inbound up on every node (killswitch enable).
+// "Already exists" is benign. Succeeds if at least one node has it.
+func (f *fanoutAdmin) AddInboundFromJSON(rawJSON string) error {
+	var failures []string
+	okCount := 0
+	for _, t := range f.targets {
+		err := t.Admin.AddInboundFromJSON(rawJSON)
+		if err == nil || isBenignExists(err) {
+			okCount++
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%s: %v", t.Name, err))
+	}
+	if len(failures) > 0 {
+		log.Printf("WARN fanout AddInboundFromJSON: %d/%d nodes failed: %s", len(failures), len(f.targets), strings.Join(failures, "; "))
+	}
+	if okCount == 0 {
+		return fmt.Errorf("AddInboundFromJSON failed on all %d nodes: %s", len(f.targets), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// RemoveInbound tears an inbound down on every node (killswitch disable).
+// "Not found"/"no such" is benign. Returns the joined real errors from nodes
+// that could not confirm removal.
+func (f *fanoutAdmin) RemoveInbound(tag string) error {
+	var failures []string
+	for _, t := range f.targets {
+		err := t.Admin.RemoveInbound(tag)
+		if err == nil || isBenignAbsent(err) {
+			continue
+		}
+		failures = append(failures, fmt.Sprintf("%s: %v", t.Name, err))
+	}
+	if len(failures) > 0 {
+		log.Printf("WARN fanout RemoveInbound %s: %d/%d nodes failed: %s", tag, len(failures), len(f.targets), strings.Join(failures, "; "))
+		return fmt.Errorf("RemoveInbound %s failed on %d node(s): %s", tag, len(failures), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// Engine reports the backing engine. All nodes are homogeneous Xray.
+func (f *fanoutAdmin) Engine() string { return "xray" }
+
+// Version returns the version of the first target, or empty when unknown.
+func (f *fanoutAdmin) Version() string {
+	if len(f.targets) == 0 {
+		return ""
+	}
+	return f.targets[0].Admin.Version()
+}
+
+func logFanoutFailures(op, inboundTag, identity string, okCount int, failures []string) {
+	if len(failures) > 0 {
+		log.Printf("WARN fanout %s %s@%s: %d ok, %d failed: %s",
+			op, identity, inboundTag, okCount, len(failures), strings.Join(failures, "; "))
+	}
+}

--- a/internal/xray/fanout_test.go
+++ b/internal/xray/fanout_test.go
@@ -1,0 +1,168 @@
+package xray
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/alchemylink/raven-subscribe/internal/core"
+)
+
+// fakeAdmin is a scriptable core.AdminAPI for exercising the fanout. It records
+// calls and returns canned results/errors.
+type fakeAdmin struct {
+	stored string // returned by AddClient
+	addErr error  // AddClient error
+	addEx  error  // AddExistingClient error
+	rmErr  error  // RemoveClient error
+	addIn  error  // AddInboundFromJSON error
+	rmIn   error  // RemoveInbound error
+
+	addCalls    int
+	addExCalls  int
+	rmCalls     int
+	addInCalls  int
+	rmInCalls   int
+}
+
+func (a *fakeAdmin) AddClient(_, _ string, _ core.AddClientHint) (string, error) {
+	a.addCalls++
+	return a.stored, a.addErr
+}
+func (a *fakeAdmin) AddExistingClient(_, _, _ string) error { a.addExCalls++; return a.addEx }
+func (a *fakeAdmin) RemoveClient(_, _ string) error         { a.rmCalls++; return a.rmErr }
+func (a *fakeAdmin) AddInboundFromJSON(_ string) error      { a.addInCalls++; return a.addIn }
+func (a *fakeAdmin) RemoveInbound(_ string) error           { a.rmInCalls++; return a.rmIn }
+func (a *fakeAdmin) Engine() string                         { return "fake" }
+func (a *fakeAdmin) Version() string                        { return "v-fake" }
+
+func named(name string, a *fakeAdmin) NamedAdmin { return NamedAdmin{Name: name, Admin: a} }
+
+func TestFanout_AddClient_AllSucceed(t *testing.T) {
+	a := &fakeAdmin{stored: `{"id":"x"}`}
+	b := &fakeAdmin{stored: `{"id":"x"}`}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	got, err := f.AddClient("vless-in", "user@z", core.AddClientHint{})
+	if err != nil {
+		t.Fatalf("AddClient: %v", err)
+	}
+	if got != `{"id":"x"}` {
+		t.Errorf("stored: got %q", got)
+	}
+	if a.addCalls != 1 || b.addCalls != 1 {
+		t.Errorf("expected fan-out to both nodes: a=%d b=%d", a.addCalls, b.addCalls)
+	}
+}
+
+func TestFanout_AddClient_PartialFailure_UserStaysOnLiveNode(t *testing.T) {
+	live := &fakeAdmin{stored: `{"id":"x"}`}
+	down := &fakeAdmin{addErr: fmt.Errorf("connection refused")}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", live), named("eu-2", down)})
+
+	got, err := f.AddClient("vless-in", "user@z", core.AddClientHint{})
+	if err != nil {
+		t.Fatalf("partial failure must not fail the op: %v", err)
+	}
+	if got != `{"id":"x"}` {
+		t.Errorf("stored from live node: got %q", got)
+	}
+	// Fan-out continues past the failure — the down node was still attempted.
+	if down.addCalls != 1 {
+		t.Errorf("down node should have been attempted, calls=%d", down.addCalls)
+	}
+}
+
+func TestFanout_AddClient_AllFail_Errors(t *testing.T) {
+	a := &fakeAdmin{addErr: fmt.Errorf("boom-a")}
+	b := &fakeAdmin{addErr: fmt.Errorf("boom-b")}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	_, err := f.AddClient("vless-in", "user@z", core.AddClientHint{})
+	if err == nil {
+		t.Fatal("expected error when all nodes fail")
+	}
+	if !strings.Contains(err.Error(), "eu-1") || !strings.Contains(err.Error(), "eu-2") {
+		t.Errorf("error should name failed nodes: %v", err)
+	}
+}
+
+func TestFanout_AddExistingClient_BenignExistsIsSuccess(t *testing.T) {
+	a := &fakeAdmin{addEx: fmt.Errorf("User user@z already exists.")}
+	b := &fakeAdmin{addErr: fmt.Errorf("unused")}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	if err := f.AddExistingClient("vless-in", "user@z", "{}"); err != nil {
+		t.Fatalf("benign already-exists must count as success: %v", err)
+	}
+}
+
+func TestFanout_RemoveClient_BenignNotFoundIsSuccess(t *testing.T) {
+	a := &fakeAdmin{rmErr: fmt.Errorf("User user@z not found.")}
+	b := &fakeAdmin{} // clean remove
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	if err := f.RemoveClient("vless-in", "user@z"); err != nil {
+		t.Fatalf("benign not-found must count as success: %v", err)
+	}
+}
+
+func TestFanout_RemoveClient_RealFailureSurfaces(t *testing.T) {
+	a := &fakeAdmin{}
+	b := &fakeAdmin{rmErr: fmt.Errorf("connection refused")}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	err := f.RemoveClient("vless-in", "user@z")
+	if err == nil {
+		t.Fatal("expected a real removal failure to surface")
+	}
+	if !strings.Contains(err.Error(), "eu-2") {
+		t.Errorf("error should name the failing node: %v", err)
+	}
+	// Removal still attempted on every node.
+	if a.rmCalls != 1 || b.rmCalls != 1 {
+		t.Errorf("remove should fan out to all: a=%d b=%d", a.rmCalls, b.rmCalls)
+	}
+}
+
+func TestFanout_AddClient_StoredMismatchStillSucceeds(t *testing.T) {
+	// Divergent stored configs across nodes are logged as drift but must not
+	// break the op — the first success wins.
+	a := &fakeAdmin{stored: `{"id":"a"}`}
+	b := &fakeAdmin{stored: `{"id":"b"}`}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	got, err := f.AddClient("vless-in", "user@z", core.AddClientHint{})
+	if err != nil {
+		t.Fatalf("AddClient: %v", err)
+	}
+	if got != `{"id":"a"}` {
+		t.Errorf("first success should win: got %q", got)
+	}
+}
+
+func TestFanout_Inbound_FanOut(t *testing.T) {
+	a := &fakeAdmin{}
+	b := &fakeAdmin{}
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
+
+	if err := f.AddInboundFromJSON(`{"tag":"x"}`); err != nil {
+		t.Fatalf("AddInboundFromJSON: %v", err)
+	}
+	if err := f.RemoveInbound("x"); err != nil {
+		t.Fatalf("RemoveInbound: %v", err)
+	}
+	if a.addInCalls != 1 || b.addInCalls != 1 || a.rmInCalls != 1 || b.rmInCalls != 1 {
+		t.Errorf("inbound ops should fan out to all nodes")
+	}
+}
+
+func TestFanout_Engine(t *testing.T) {
+	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", &fakeAdmin{})})
+	if f.Engine() != "xray" {
+		t.Errorf("Engine: got %q, want xray", f.Engine())
+	}
+	if f.Version() != "v-fake" {
+		t.Errorf("Version should come from first target: got %q", f.Version())
+	}
+}

--- a/internal/xray/fanout_test.go
+++ b/internal/xray/fanout_test.go
@@ -88,7 +88,9 @@ func TestFanout_AddClient_AllFail_Errors(t *testing.T) {
 }
 
 func TestFanout_AddExistingClient_BenignExistsIsSuccess(t *testing.T) {
-	a := &fakeAdmin{addEx: fmt.Errorf("User user@z already exists.")}
+	// Xray's real reply is "User X already exists." — the matcher is
+	// case-insensitive substring ("exist"), so a lowercased form tests the same.
+	a := &fakeAdmin{addEx: fmt.Errorf("user user@z already exists")}
 	b := &fakeAdmin{addErr: fmt.Errorf("unused")}
 	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
 
@@ -98,7 +100,8 @@ func TestFanout_AddExistingClient_BenignExistsIsSuccess(t *testing.T) {
 }
 
 func TestFanout_RemoveClient_BenignNotFoundIsSuccess(t *testing.T) {
-	a := &fakeAdmin{rmErr: fmt.Errorf("User user@z not found.")}
+	// Xray's real reply is "User X not found." — matched case-insensitively.
+	a := &fakeAdmin{rmErr: fmt.Errorf("user user@z not found")}
 	b := &fakeAdmin{} // clean remove
 	f := NewFanoutAdmin([]NamedAdmin{named("eu-1", a), named("eu-2", b)})
 

--- a/internal/xray/impl.go
+++ b/internal/xray/impl.go
@@ -15,6 +15,11 @@ import (
 // belt-and-suspenders the config file too, so a client added via gRPC that
 // happened to also be present on disk (e.g. after a restore) doesn't
 // resurrect after an Xray restart reloads config.d.
+//
+// When configDir is empty the admin runs in grpc-only mode: it never touches
+// local config files. This is used for remote fanout nodes (multi-node), whose
+// config.d is not on this host — durability there comes from the per-node
+// reconcile loop, not from a local file mirror (see docs/multi-node-design.md §8).
 type grpcAdmin struct {
 	apiAddr   string
 	configDir string
@@ -24,8 +29,9 @@ type grpcAdmin struct {
 var _ core.AdminAPI = (*grpcAdmin)(nil)
 
 // NewGRPCAdmin returns a core.AdminAPI backed by Xray's gRPC HandlerService at
-// apiAddr. configDir/filePerm are used only for the config-file cleanup half
-// of RemoveClient described above.
+// apiAddr. A non-empty configDir enables the config-file mirror in RemoveClient
+// (and the protocol lookup in AddClient); an empty configDir makes the admin
+// grpc-only (remote fanout node).
 func NewGRPCAdmin(apiAddr, configDir string, filePerm os.FileMode) core.AdminAPI {
 	return &grpcAdmin{apiAddr: apiAddr, configDir: configDir, filePerm: filePerm}
 }
@@ -40,6 +46,9 @@ func (a *grpcAdmin) AddExistingClient(inboundTag, identity, storedConfigJSON str
 
 func (a *grpcAdmin) RemoveClient(inboundTag, identity string) error {
 	apiErr := RemoveUserFromInboundViaAPI(a.apiAddr, inboundTag, identity)
+	if a.configDir == "" {
+		return apiErr // grpc-only: no local config.d to mirror
+	}
 	fileErr := RemoveUserFromInbound(a.configDir, inboundTag, identity, a.filePerm)
 	return errors.Join(apiErr, fileErr)
 }


### PR DESCRIPTION
Part of the multi-node design (#100). **Phase 2** of `docs/multi-node-design.md` (§6.1/§6.4/§9) — the fan-out write path. Single-node behavior is byte-identical; multi-node CRUD now reaches every node.

## What's in
- **`internal/xray/fanout.go`** — `fanoutAdmin` implements `core.AdminAPI` over a set of `NamedAdmin` targets, hiding N nodes behind the same interface `api.Server` already uses (Phase 0 seam). Failure policy per §6.4 — partial failures are **never rolled back** and stay visible via per-node warnings:
  - additive ops (`AddClient`/`AddExistingClient`/`AddInboundFromJSON`) succeed when **≥1 node** applied them; `"already exists"` counts as applied. `AddClient` returns the first node's stored credential (nodes are homogeneous) and logs any divergent success as cross-node config drift.
  - removals (`RemoveClient`/`RemoveInbound`) treat `"not found"` as already-done and return the joined real errors from nodes that couldn't confirm, so a **down node stays visible** until the reconcile loop (Phase 4) cleans it up.
  - benign `"already exists"`/`"not found"` matching reuses the idioms from `api/fallback.go` (§13.2).
- **`internal/xray/impl.go`** — `grpcAdmin` now runs **grpc-only when `configDir` is empty** (skips the local config-file mirror in `RemoveClient`). Remote fanout nodes have no local `config.d`; their durability is the reconcile loop, not a file mirror (§8). Single-node path passes a real `configDir` → unchanged.
- **`api/server.go`** — `buildAdmin()` selects the backend: multi-node (`nodes` configured) → fanout over grpc-only per-node admins; single-node (no `nodes`) → the legacy grpc-with-mirror / file-backed path, byte-identical.

## Design notes
- Fans out to **all enabled nodes** (homogeneous + all-placement default from Phase 1). Per-user subset routing (filtering the fanout by `user_nodes`) lands with the placement API in a later phase; until then every user is on every node anyway, so a global fanout is correct.
- `core.AdminAPI` signatures are unchanged — the fanout hides behind the same interface (§6.1), so no call site in `server.go` changed.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race -count=1` — all green
- [x] `golangci-lint`, `staticcheck`, `gosec`, `go mod tidy` — 0 issues / no diff
- [x] New `fanout_test.go` with fake `core.AdminAPI` targets: fan-out to all; **partial failure (1 of 2 down → user on live node, no error, down node still attempted)**; all-fail → error naming both nodes; benign already-exists/not-found swallowed; real removal failure surfaces + names the node; stored-config mismatch logged but op succeeds; inbound ops fan out; Engine/Version.