### PR TITLE
feat(multi-node): per-node outbounds in generated configs — Phase 3

### DIFF
--- a/internal/api/nodes.go
+++ b/internal/api/nodes.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"log"
+
+	"github.com/alchemylink/raven-subscribe/internal/models"
+)
+
+// expandClientsForNodes turns a user's per-inbound client list into a
+// per-node-endpoint list for multi-node subscription generation (Phase 3,
+// docs/multi-node-design.md §6.3).
+//
+// Single-node (no nodes configured): returns clients unchanged, so generated
+// configs stay byte-identical to before.
+//
+// Multi-node: for each enabled node the user is placed on (user_nodes), emit a
+// copy of the client whose inbound matches the node's inbound_tag, tagged with
+// that node's public endpoint. A user on N nodes serving the same inbound thus
+// yields N outbounds that the generator places under one balancer. A client
+// whose inbound is served by no placed node is dropped — in multi-node mode
+// endpoints come from nodes, so it has nowhere to point.
+func (s *Server) expandClientsForNodes(userID int64, clients []models.UserClientFull) []models.UserClientFull {
+	if len(s.cfg.Nodes) == 0 {
+		return clients
+	}
+
+	nodeIDs, err := s.db.ListNodeIDsForUser(userID)
+	if err != nil {
+		// #nosec G706 -- userID is an int64 (not injectable) and err is an internal DB error.
+		log.Printf("WARN multi-node: list node placements for user %d: %v — falling back to single-endpoint", userID, err)
+		return clients
+	}
+	if len(nodeIDs) == 0 {
+		return clients
+	}
+	placed := make(map[int64]bool, len(nodeIDs))
+	for _, id := range nodeIDs {
+		placed[id] = true
+	}
+
+	allNodes, err := s.db.ListNodes()
+	if err != nil {
+		log.Printf("WARN multi-node: list nodes: %v — falling back to single-endpoint", err)
+		return clients
+	}
+	// inbound tag -> the enabled, placed nodes serving it.
+	byTag := make(map[string][]models.Node)
+	for _, n := range allNodes {
+		if !n.Enabled || !placed[n.ID] {
+			continue
+		}
+		byTag[n.InboundTag] = append(byTag[n.InboundTag], n)
+	}
+
+	expanded := make([]models.UserClientFull, 0, len(clients))
+	for _, c := range clients {
+		nodes := byTag[c.InboundTag]
+		if len(nodes) == 0 {
+			// No placed node serves this inbound; nothing to point an outbound at.
+			continue
+		}
+		for _, n := range nodes {
+			cp := c
+			cp.NodeName = n.Name
+			cp.NodeHost = n.PublicHost
+			cp.NodePort = n.PublicPort
+			expanded = append(expanded, cp)
+		}
+	}
+	return expanded
+}

--- a/internal/api/nodes_test.go
+++ b/internal/api/nodes_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/alchemylink/raven-subscribe/internal/config"
+	"github.com/alchemylink/raven-subscribe/internal/database"
+	"github.com/alchemylink/raven-subscribe/internal/models"
+)
+
+func nodeTestServer(t *testing.T, nodes []config.NodeConfig) (*Server, *database.DB) {
+	t.Helper()
+	db, err := database.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	cfg := &config.Config{ServerHost: "eu.example.com", BaseURL: "http://eu.example.com", Nodes: nodes}
+	return NewServer(cfg, db, &noopSyncer{}), db
+}
+
+func clientOn(tag string) models.UserClientFull {
+	return models.UserClientFull{
+		UserClient:      models.UserClient{ClientConfig: `{"protocol":"vless","id":"u"}`},
+		InboundTag:      tag,
+		InboundProtocol: "vless",
+		InboundPort:     443,
+	}
+}
+
+func TestExpandClientsForNodes_SingleNodeNoOp(t *testing.T) {
+	srv, _ := nodeTestServer(t, nil) // no nodes configured
+	clients := []models.UserClientFull{clientOn("vless-in")}
+	got := srv.expandClientsForNodes(1, clients)
+	if len(got) != 1 || got[0].NodeHost != "" {
+		t.Fatalf("single-node must be a no-op, got %+v", got)
+	}
+}
+
+func TestExpandClientsForNodes_ExpandsPerPlacedNode(t *testing.T) {
+	nodes := []config.NodeConfig{
+		{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443},
+		{Name: "eu-2", APIAddr: "10.7.0.2:10085", InboundTag: "vless-in", PublicHost: "eu2.example.com", PublicPort: 8443},
+	}
+	srv, db := nodeTestServer(t, nodes)
+
+	u, err := db.CreateUser("alice", "", "tok", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	id1, _ := db.UpsertNode(models.Node{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443, Enabled: true})
+	id2, _ := db.UpsertNode(models.Node{Name: "eu-2", APIAddr: "10.7.0.2:10085", InboundTag: "vless-in", PublicHost: "eu2.example.com", PublicPort: 8443, Enabled: true})
+	if err := db.AssignUserToNodes(u.ID, []int64{id1, id2}); err != nil {
+		t.Fatalf("AssignUserToNodes: %v", err)
+	}
+
+	got := srv.expandClientsForNodes(u.ID, []models.UserClientFull{clientOn("vless-in")})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 expanded clients, got %d", len(got))
+	}
+	hosts := map[string]int{}
+	for _, c := range got {
+		hosts[c.NodeHost] = c.NodePort
+	}
+	if hosts["eu1.example.com"] != 443 || hosts["eu2.example.com"] != 8443 {
+		t.Errorf("unexpected node endpoints: %v", hosts)
+	}
+}
+
+func TestExpandClientsForNodes_SkipsClientWithNoPlacedNode(t *testing.T) {
+	nodes := []config.NodeConfig{
+		{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443},
+	}
+	srv, db := nodeTestServer(t, nodes)
+
+	u, err := db.CreateUser("bob", "", "tok2", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	id1, _ := db.UpsertNode(models.Node{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443, Enabled: true})
+	if err := db.AssignUserToNodes(u.ID, []int64{id1}); err != nil {
+		t.Fatalf("AssignUserToNodes: %v", err)
+	}
+
+	// Client on an inbound no placed node serves → dropped; client on vless-in → kept.
+	clients := []models.UserClientFull{clientOn("vless-xhttp-in"), clientOn("vless-in")}
+	got := srv.expandClientsForNodes(u.ID, clients)
+	if len(got) != 1 {
+		t.Fatalf("expected only the served inbound to survive, got %d", len(got))
+	}
+	if got[0].InboundTag != "vless-in" || got[0].NodeHost != "eu1.example.com" {
+		t.Errorf("wrong surviving client: %+v", got[0])
+	}
+}
+
+func TestExpandClientsForNodes_NoPlacementFallsBack(t *testing.T) {
+	// Nodes configured but the user has no placements yet: fall back to the
+	// unexpanded clients rather than dropping everything.
+	nodes := []config.NodeConfig{{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443}}
+	srv, db := nodeTestServer(t, nodes)
+	u, err := db.CreateUser("carol", "", "tok3", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	got := srv.expandClientsForNodes(u.ID, []models.UserClientFull{clientOn("vless-in")})
+	if len(got) != 1 || got[0].NodeHost != "" {
+		t.Fatalf("no placement should fall back to unexpanded clients, got %+v", got)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -369,6 +369,12 @@ func (s *Server) handleSubscription(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	clients = s.expandClientsForNodes(user.ID, clients)
+	if len(clients) == 0 {
+		jsonError(w, "no client endpoints after node placement", http.StatusNotFound)
+		return
+	}
+
 	cfg, err := xray.GenerateClientConfig(
 		s.effectiveHost(r),
 		s.effectiveInboundHosts(r),

--- a/internal/api/sub_links.go
+++ b/internal/api/sub_links.go
@@ -353,6 +353,10 @@ func (s *Server) generateConfigForSubscriptionRequestWithForcedProtocol(r *http.
 	if err != nil {
 		return nil, "", fmt.Errorf("internal error")
 	}
+	clients = s.expandClientsForNodes(user.ID, clients)
+	if len(clients) == 0 {
+		return nil, "", fmt.Errorf("no client endpoints after node placement")
+	}
 	cfg, err := xray.GenerateClientConfig(
 		s.effectiveHost(r),
 		s.effectiveInboundHosts(r),

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -76,6 +76,15 @@ type UserClientFull struct {
 	InboundProtocol string `json:"inbound_protocol"`
 	InboundPort     int    `json:"inbound_port"`
 	InboundRaw      string `json:"inbound_raw"`
+
+	// Multi-node generation hints. Populated only by the node expansion in the
+	// API layer (docs/multi-node-design.md §6.3); empty in single-node mode.
+	// When NodeHost is set the generator emits this client's outbound pointing
+	// at that node's public endpoint instead of server_host, so a user placed
+	// on N nodes yields N balanced outbounds. NodeName is diagnostic only.
+	NodeName string `json:"-"`
+	NodeHost string `json:"-"`
+	NodePort int    `json:"-"`
 }
 
 // InboundSpec specifies an inbound to add the user to. Protocol is optional — derived from tag via DB/config when omitted.

--- a/internal/xray/generator.go
+++ b/internal/xray/generator.go
@@ -68,6 +68,16 @@ func GenerateClientConfig(serverHost string, inboundHosts map[string]string, inb
 		if p, ok := inboundPorts[uc.InboundTag]; ok && p > 0 {
 			uc.InboundPort = p
 		}
+		// Multi-node: a per-node expanded client points the outbound at that
+		// node's public endpoint. Node wins over serverHost/inboundHosts so each
+		// placed node becomes its own balanced outbound (§6.3). Empty in
+		// single-node mode, leaving the resolution above byte-identical.
+		if strings.TrimSpace(uc.NodeHost) != "" {
+			host = uc.NodeHost
+		}
+		if uc.NodePort > 0 {
+			uc.InboundPort = uc.NodePort
+		}
 		ob, err := buildOutbound(host, uc, i)
 		if err != nil {
 			log.Printf("WARN: build outbound for inbound %s: %v", uc.InboundTag, err)

--- a/internal/xray/generator_nodes_test.go
+++ b/internal/xray/generator_nodes_test.go
@@ -1,0 +1,107 @@
+package xray
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alchemylink/raven-subscribe/internal/models"
+)
+
+// vnextEndpoint extracts the address and port from a vless/vmess-style outbound.
+func vnextEndpoint(t *testing.T, ob Outbound) (string, int) {
+	t.Helper()
+	var s struct {
+		Vnext []struct {
+			Address string `json:"address"`
+			Port    int    `json:"port"`
+		} `json:"vnext"`
+	}
+	if err := json.Unmarshal(ob.Settings, &s); err != nil {
+		t.Fatalf("unmarshal outbound settings: %v", err)
+	}
+	if len(s.Vnext) == 0 {
+		t.Fatalf("outbound %s has no vnext server", ob.Tag)
+	}
+	return s.Vnext[0].Address, s.Vnext[0].Port
+}
+
+func vlessClient(tag string) models.UserClientFull {
+	return models.UserClientFull{
+		UserClient:      models.UserClient{ClientConfig: `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision","encryption":"none"}`},
+		InboundTag:      tag,
+		InboundProtocol: "vless",
+		InboundPort:     443,
+		InboundRaw:      `{"tag":"` + tag + `","protocol":"vless","port":443,"settings":{"decryption":"none","clients":[{"id":"uuid1","email":"u@test.com","flow":"xtls-rprx-vision"}]},"streamSettings":{"network":"tcp"}}`,
+	}
+}
+
+// Golden N=1: a client with no node hints must resolve to server_host:inbound_port,
+// exactly as before multi-node existed.
+func TestGenerate_NoNodeHint_UsesServerHost(t *testing.T) {
+	clients := []models.UserClientFull{vlessClient("vless-in")}
+	cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, clients, "", "", "", "", 0, 0, nil, "")
+	if err != nil {
+		t.Fatalf("GenerateClientConfig: %v", err)
+	}
+	addr, port := vnextEndpoint(t, cfg.Outbounds[0])
+	if addr != "example.com" {
+		t.Errorf("address: got %q, want example.com", addr)
+	}
+	if port != 443 {
+		t.Errorf("port: got %d, want 443", port)
+	}
+}
+
+// A node-expanded client points its outbound at the node's public endpoint,
+// overriding server_host.
+func TestGenerate_NodeOverride_UsesNodeEndpoint(t *testing.T) {
+	c := vlessClient("vless-in")
+	c.NodeName = "eu-2"
+	c.NodeHost = "eu2.example.com"
+	c.NodePort = 8443
+	cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, []models.UserClientFull{c}, "", "", "", "", 0, 0, nil, "")
+	if err != nil {
+		t.Fatalf("GenerateClientConfig: %v", err)
+	}
+	addr, port := vnextEndpoint(t, cfg.Outbounds[0])
+	if addr != "eu2.example.com" || port != 8443 {
+		t.Errorf("node endpoint: got %s:%d, want eu2.example.com:8443", addr, port)
+	}
+}
+
+// Two nodes serving the same inbound produce two distinct proxy outbounds
+// gathered under one balancer.
+func TestGenerate_TwoNodes_BalancedOutbounds(t *testing.T) {
+	a := vlessClient("vless-in")
+	a.NodeName, a.NodeHost, a.NodePort = "eu-1", "eu1.example.com", 443
+	b := vlessClient("vless-in")
+	b.NodeName, b.NodeHost, b.NodePort = "eu-2", "eu2.example.com", 443
+
+	cfg, err := GenerateClientConfig("example.com", nil, nil, models.User{Username: "u"}, []models.UserClientFull{a, b}, "", "", "", "", 0, 0, nil, "")
+	if err != nil {
+		t.Fatalf("GenerateClientConfig: %v", err)
+	}
+
+	hosts := map[string]bool{}
+	proxyCount := 0
+	for _, ob := range cfg.Outbounds {
+		if ob.Protocol != "vless" {
+			continue
+		}
+		proxyCount++
+		addr, _ := vnextEndpoint(t, ob)
+		hosts[addr] = true
+	}
+	if proxyCount != 2 {
+		t.Fatalf("expected 2 proxy outbounds, got %d", proxyCount)
+	}
+	if !hosts["eu1.example.com"] || !hosts["eu2.example.com"] {
+		t.Errorf("expected both node hosts, got %v", hosts)
+	}
+	if len(cfg.Routing.Balancers) != 1 {
+		t.Fatalf("expected 1 balancer over the node outbounds, got %d", len(cfg.Routing.Balancers))
+	}
+	if cfg.Routing.Balancers[0].Tag != "proxy-balance" {
+		t.Errorf("balancer tag: got %q", cfg.Routing.Balancers[0].Tag)
+	}
+}


### PR DESCRIPTION
Part of the multi-node design (#100). **Phase 3** of `docs/multi-node-design.md` (§6.3/§9) — the generator now emits one balanced outbound per node a user is placed on. Single-node output is byte-identical.

## What's in
- **`models.UserClientFull`** gains `NodeName`/`NodeHost`/`NodePort` (`json:"-"`), populated only by the node expansion; empty in single-node mode.
- **generator** — when a client carries a `NodeHost`, its outbound points at that node's public endpoint (node wins over `server_host`/`inbound_hosts`). Empty hints leave endpoint resolution **byte-identical** to before.
- **api** — `expandClientsForNodes()` is a **no-op when no nodes are configured**; in multi-node it clones each client once per enabled placed node serving that `inbound_tag`, tagging it with the node's public endpoint. Wired before `GenerateClientConfig` in both callers (`sub_links.go`, `server.go`). A client whose inbound is served by no placed node is dropped; a user with no placements at all falls back to the unexpanded clients.

## Result
The existing balancer gathers the per-node outbounds under one `proxy-balance` (XHTTP-first preference preserved), so endpoint selection across nodes is the client's `leastPing`/`leastLoad` — *"subscription generation includes target endpoint selection"* from the issue. Fallback/emergency × multi-node is deferred (§11).

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race -count=1` — all green (existing single-node tests unchanged)
- [x] `golangci-lint` (Test + Security `-E gosec -E misspell -E revive`), `staticcheck`, standalone `gosec`, `go mod tidy` — 0 issues / no diff
- [x] New tests — generator: **golden N=1** (no hints → `server_host:inbound_port`), node override → node endpoint, **N=2 two nodes → 2 proxy outbounds under one balancer with distinct hosts**; api: `expandClientsForNodes` no-op single-node, expands per placed node, skips client with no placed node, falls back on zero placement

_Note: caught mid-work that earlier `go` commands had run against the main checkout rather than the worktree; all gates above were re-run in the worktree against the actual Phase 3 changes._