### PR TITLE
feat(multi-node): node listing + per-user placement API — Phase 4a

### DIFF
--- a/internal/api/nodes.go
+++ b/internal/api/nodes.go
@@ -1,7 +1,13 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
 
 	"github.com/alchemylink/raven-subscribe/internal/models"
 )
@@ -68,4 +74,155 @@ func (s *Server) expandClientsForNodes(userID int64, clients []models.UserClient
 		}
 	}
 	return expanded
+}
+
+// ── Node topology + placement API (admin) ────────────────────────────────────
+
+// listNodes returns the node topology from the DB. Read-only: node definitions
+// are managed in config (reconciled at startup, docs/multi-node-design.md §5),
+// not created via the API. Works in single-node too (returns the implicit
+// "local" node).
+func (s *Server) listNodes(w http.ResponseWriter, _ *http.Request) {
+	nodes, err := s.db.ListNodes()
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if nodes == nil {
+		nodes = []models.Node{}
+	}
+	jsonOK(w, nodes)
+}
+
+// getUserNodes lists the nodes a user is placed on.
+func (s *Server) getUserNodes(w http.ResponseWriter, r *http.Request) {
+	user, err := s.getByID(w, r)
+	if user == nil || err != nil {
+		return
+	}
+	nodes, err := s.db.ListNodesForUser(user.ID)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if nodes == nil {
+		nodes = []models.Node{}
+	}
+	jsonOK(w, nodes)
+}
+
+// setUserNodes replaces a user's node placement. Body: {"nodes":["eu-1","eu-2"]}.
+// Placement only affects which node endpoints appear in the user's subscription
+// (provisioning already fans out to every node), so this is a pure user_nodes
+// write. Rejected when multi-node is not configured.
+func (s *Server) setUserNodes(w http.ResponseWriter, r *http.Request) {
+	if len(s.cfg.Nodes) == 0 {
+		jsonError(w, "multi-node not configured", http.StatusBadRequest)
+		return
+	}
+	user, err := s.getByID(w, r)
+	if user == nil || err != nil {
+		return
+	}
+	var body struct {
+		Nodes []string `json:"nodes"`
+	}
+	if err := json.NewDecoder(limitRequestBody(r)).Decode(&body); err != nil {
+		jsonError(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+	ids, bad, err := s.resolveNodeNames(body.Nodes)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(bad) > 0 {
+		jsonError(w, "unknown node(s): "+strings.Join(bad, ", "), http.StatusBadRequest)
+		return
+	}
+	if err := s.db.SetUserNodes(user.ID, ids); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	nodes, _ := s.db.ListNodesForUser(user.ID)
+	if nodes == nil {
+		nodes = []models.Node{}
+	}
+	jsonOK(w, nodes)
+}
+
+// deleteUserNode removes a single placement by node name. Rejected when
+// multi-node is not configured.
+func (s *Server) deleteUserNode(w http.ResponseWriter, r *http.Request) {
+	if len(s.cfg.Nodes) == 0 {
+		jsonError(w, "multi-node not configured", http.StatusBadRequest)
+		return
+	}
+	user, err := s.getByID(w, r)
+	if user == nil || err != nil {
+		return
+	}
+	name := strings.TrimSpace(mux.Vars(r)["nodeName"])
+	node, err := s.db.GetNodeByName(name)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if node == nil {
+		jsonError(w, "node not found", http.StatusNotFound)
+		return
+	}
+	if err := s.db.RemoveUserFromNode(user.ID, node.ID); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]string{"status": "removed", "node": name})
+}
+
+// resolveNodeNames maps node names to their ids. Returns the ids for known
+// names and the list of names that don't exist; err is only a real DB error.
+func (s *Server) resolveNodeNames(names []string) (ids []int64, bad []string, err error) {
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		n, err := s.db.GetNodeByName(name)
+		if err != nil {
+			return nil, nil, err
+		}
+		if n == nil {
+			bad = append(bad, name)
+			continue
+		}
+		ids = append(ids, n.ID)
+	}
+	return ids, bad, nil
+}
+
+// placeUserOnNodes sets a new user's placement in multi-node mode: the given
+// node names, or all enabled nodes when none are given (default policy §11).
+// No-op in single-node mode. Callers should pre-validate explicit names.
+func (s *Server) placeUserOnNodes(userID int64, names []string) error {
+	if len(s.cfg.Nodes) == 0 {
+		return nil
+	}
+	var ids []int64
+	if len(names) > 0 {
+		var bad []string
+		var err error
+		ids, bad, err = s.resolveNodeNames(names)
+		if err != nil {
+			return err
+		}
+		if len(bad) > 0 {
+			return fmt.Errorf("unknown node(s): %s", strings.Join(bad, ", "))
+		}
+	} else {
+		var err error
+		if ids, err = s.db.EnabledNodeIDs(); err != nil {
+			return err
+		}
+	}
+	return s.db.SetUserNodes(userID, ids)
 }

--- a/internal/api/nodes_api_test.go
+++ b/internal/api/nodes_api_test.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/alchemylink/raven-subscribe/internal/config"
+	"github.com/alchemylink/raven-subscribe/internal/database"
+	"github.com/alchemylink/raven-subscribe/internal/models"
+)
+
+func itoa(n int64) string { return strconv.FormatInt(n, 10) }
+
+// multiNodeServer builds an admin-authed Server with the given node topology
+// reconciled into the DB.
+func multiNodeServer(t *testing.T, nodes []config.NodeConfig) (*Server, *database.DB) {
+	t.Helper()
+	db, err := database.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	for _, n := range nodes {
+		if _, err := db.UpsertNode(models.Node{
+			Name: n.Name, APIAddr: n.APIAddr, InboundTag: n.InboundTag,
+			PublicHost: n.PublicHost, PublicPort: n.PublicPort, Enabled: n.IsEnabled(),
+		}); err != nil {
+			t.Fatalf("UpsertNode: %v", err)
+		}
+	}
+	cfg := &config.Config{ServerHost: "eu.example.com", BaseURL: "http://eu.example.com", AdminToken: "admin-secret", Nodes: nodes}
+	return NewServer(cfg, db, &noopSyncer{}), db
+}
+
+func adminReq(method, path, body string) *http.Request {
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	r.Header.Set("X-Admin-Token", "admin-secret")
+	return r
+}
+
+func twoNodes() []config.NodeConfig {
+	return []config.NodeConfig{
+		{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443},
+		{Name: "eu-2", APIAddr: "10.7.0.2:10085", InboundTag: "vless-in", PublicHost: "eu2.example.com", PublicPort: 443},
+	}
+}
+
+func TestListNodes(t *testing.T) {
+	srv, _ := multiNodeServer(t, twoNodes())
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodGet, "/api/nodes", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/nodes: status %d", rec.Code)
+	}
+	var nodes []models.Node
+	if err := json.Unmarshal(rec.Body.Bytes(), &nodes); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Errorf("expected 2 nodes, got %d", len(nodes))
+	}
+}
+
+func TestSetAndGetUserNodes(t *testing.T) {
+	srv, db := multiNodeServer(t, twoNodes())
+	u, _ := db.CreateUser("alice", "", "tok", "")
+
+	// Place on eu-1 only.
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users/"+itoa(u.ID)+"/nodes", `{"nodes":["eu-1"]}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST placement: status %d body %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodGet, "/api/users/"+itoa(u.ID)+"/nodes", ""))
+	var nodes []models.Node
+	_ = json.Unmarshal(rec.Body.Bytes(), &nodes)
+	if len(nodes) != 1 || nodes[0].Name != "eu-1" {
+		t.Fatalf("placement: got %+v, want [eu-1]", nodes)
+	}
+}
+
+func TestSetUserNodes_UnknownNodeIs400(t *testing.T) {
+	srv, db := multiNodeServer(t, twoNodes())
+	u, _ := db.CreateUser("bob", "", "tok2", "")
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users/"+itoa(u.ID)+"/nodes", `{"nodes":["eu-9"]}`))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown node should be 400, got %d (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPlacementRejectedSingleNode(t *testing.T) {
+	// No nodes configured => placement mutation is 400.
+	db, err := database.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	cfg := &config.Config{ServerHost: "eu.example.com", BaseURL: "http://eu.example.com", AdminToken: "admin-secret"}
+	srv := NewServer(cfg, db, &noopSyncer{})
+	u, _ := db.CreateUser("carol", "", "tok3", "")
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users/"+itoa(u.ID)+"/nodes", `{"nodes":["local"]}`))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("placement in single-node should be 400, got %d", rec.Code)
+	}
+}
+
+func TestDeleteUserNode(t *testing.T) {
+	srv, db := multiNodeServer(t, twoNodes())
+	u, _ := db.CreateUser("dave", "", "tok4", "")
+	id1, _ := db.GetNodeByName("eu-1")
+	id2, _ := db.GetNodeByName("eu-2")
+	if err := db.SetUserNodes(u.ID, []int64{id1.ID, id2.ID}); err != nil {
+		t.Fatalf("SetUserNodes: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodDelete, "/api/users/"+itoa(u.ID)+"/nodes/eu-1", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE placement: status %d", rec.Code)
+	}
+	nodes, _ := db.ListNodesForUser(u.ID)
+	if len(nodes) != 1 || nodes[0].Name != "eu-2" {
+		t.Errorf("after delete: got %+v, want [eu-2]", nodes)
+	}
+}
+
+func TestCreateUser_DefaultPlacesOnAllEnabledNodes(t *testing.T) {
+	srv, db := multiNodeServer(t, twoNodes())
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users", `{"username":"erin@z.com"}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create user: status %d body %s", rec.Code, rec.Body.String())
+	}
+	u, err := db.GetUserByUsername("erin@z.com")
+	if err != nil || u == nil {
+		t.Fatalf("user not created: %v", err)
+	}
+	nodes, _ := db.ListNodesForUser(u.ID)
+	if len(nodes) != 2 {
+		t.Errorf("default placement should be all enabled nodes, got %d", len(nodes))
+	}
+}
+
+func TestCreateUser_ExplicitNodeSubset(t *testing.T) {
+	srv, db := multiNodeServer(t, twoNodes())
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users", `{"username":"frank@z.com","nodes":["eu-2"]}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create user: status %d body %s", rec.Code, rec.Body.String())
+	}
+	u, _ := db.GetUserByUsername("frank@z.com")
+	nodes, _ := db.ListNodesForUser(u.ID)
+	if len(nodes) != 1 || nodes[0].Name != "eu-2" {
+		t.Errorf("explicit subset: got %+v, want [eu-2]", nodes)
+	}
+}
+
+func TestCreateUser_UnknownNodeIs400(t *testing.T) {
+	srv, _ := multiNodeServer(t, twoNodes())
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users", `{"username":"grace@z.com","nodes":["nope"]}`))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown node on create should be 400, got %d", rec.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -175,6 +175,12 @@ func (s *Server) Router() http.Handler {
 	api.HandleFunc("/sync", s.triggerSync).Methods(http.MethodPost)
 	api.HandleFunc("/sync/status", s.handleSyncStatus).Methods(http.MethodGet)
 
+	// ── Multi-node topology + per-user placement ──────────────────────────────
+	api.HandleFunc("/nodes", s.listNodes).Methods(http.MethodGet)
+	api.HandleFunc("/users/{id}/nodes", s.getUserNodes).Methods(http.MethodGet)
+	api.HandleFunc("/users/{id}/nodes", s.setUserNodes).Methods(http.MethodPost)
+	api.HandleFunc("/users/{id}/nodes/{nodeName}", s.deleteUserNode).Methods(http.MethodDelete)
+
 	// ── Fallback management ───────────────────────────────────────────────────
 	api.HandleFunc("/users/{id}/fallback/token", s.regenerateFallbackToken).Methods(http.MethodPost)
 	api.HandleFunc("/fallback/status", s.getFallbackStatus).Methods(http.MethodGet)
@@ -613,6 +619,18 @@ func (s *Server) createUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate explicit node placement before creating the user, so a bad node
+	// name fails cleanly rather than leaving a created-but-unplaced user.
+	if len(s.cfg.Nodes) > 0 && len(req.Nodes) > 0 {
+		if _, bad, err := s.resolveNodeNames(req.Nodes); err != nil {
+			jsonError(w, err.Error(), http.StatusInternalServerError)
+			return
+		} else if len(bad) > 0 {
+			jsonError(w, "unknown node(s): "+strings.Join(bad, ", "), http.StatusBadRequest)
+			return
+		}
+	}
+
 	token := generateToken()
 	fallbackToken := generateToken()
 	// Email in DB mirrors username for Xray; not accepted on create and not exposed in API JSON.
@@ -654,6 +672,14 @@ func (s *Server) createUser(w http.ResponseWriter, r *http.Request) {
 
 	if len(inboundsToAdd) > 0 && s.cfg.XrayAPIAddr == "" {
 		go func() { _ = s.syncer.Sync() }()
+	}
+
+	// Multi-node: place the user on the requested nodes (or all enabled by
+	// default). Names were validated above, so this only fails on a DB error —
+	// log it rather than failing the create (the user exists and provisioning
+	// already fanned out; the startup backfill will place them otherwise).
+	if err := s.placeUserOnNodes(user.ID, req.Nodes); err != nil {
+		log.Printf("WARN create user %s: set node placement: %v", sanitizeLogField(username), err)
 	}
 
 	jsonOK(w, models.UserResponse{User: *user, SubURL: s.cfg.SubURL(user.Token), SubURLs: s.cfg.SubURLsWithFallback(user.Token, user.FallbackToken)})

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1107,6 +1107,78 @@ func (db *DB) ListNodeIDsForUser(userID int64) ([]int64, error) {
 	return ids, rows.Err()
 }
 
+// ListNodesForUser returns the full node rows a user is placed on, ordered by name.
+func (db *DB) ListNodesForUser(userID int64) ([]models.Node, error) {
+	rows, err := db.conn.Query(
+		`SELECT n.id, n.name, n.api_addr, n.inbound_tag, n.public_host, n.public_port, n.enabled, n.created_at
+		 FROM nodes n
+		 JOIN user_nodes un ON un.node_id = n.id
+		 WHERE un.user_id = ?
+		 ORDER BY n.name`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var nodes []models.Node
+	for rows.Next() {
+		var n models.Node
+		var enabled int
+		if err := rows.Scan(&n.ID, &n.Name, &n.APIAddr, &n.InboundTag, &n.PublicHost, &n.PublicPort, &enabled, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		n.Enabled = enabled != 0
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// SetUserNodes replaces a user's placement set with exactly the given node ids
+// (add missing, drop extra). An empty slice clears all placements. Runs in a
+// transaction so a subscription read never sees a half-applied set.
+func (db *DB) SetUserNodes(userID int64, nodeIDs []int64) error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }() // no-op after Commit
+
+	if _, err := tx.Exec(`DELETE FROM user_nodes WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+	for _, nid := range nodeIDs {
+		if _, err := tx.Exec(`INSERT OR IGNORE INTO user_nodes (user_id, node_id) VALUES (?, ?)`, userID, nid); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// RemoveUserFromNode drops a single placement. No-op if the user was not on the node.
+func (db *DB) RemoveUserFromNode(userID, nodeID int64) error {
+	_, err := db.conn.Exec(`DELETE FROM user_nodes WHERE user_id = ? AND node_id = ?`, userID, nodeID)
+	return err
+}
+
+// EnabledNodeIDs returns the ids of all enabled nodes, ordered by name.
+func (db *DB) EnabledNodeIDs() ([]int64, error) {
+	rows, err := db.conn.Query(`SELECT id FROM nodes WHERE enabled = 1 ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 func boolInt(b bool) int {

--- a/internal/database/nodes_test.go
+++ b/internal/database/nodes_test.go
@@ -206,3 +206,107 @@ func TestUserNodes_CascadeOnUserDelete(t *testing.T) {
 		t.Errorf("user_nodes should cascade-delete with user, got %v", ids)
 	}
 }
+
+func TestSetUserNodes_ReplacesSet(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	u, err := db.CreateUser("alice", "", "tok", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	a, _ := db.UpsertNode(models.Node{Name: "a", APIAddr: "10.7.0.1:10085", Enabled: true})
+	b, _ := db.UpsertNode(models.Node{Name: "b", APIAddr: "10.7.0.2:10085", Enabled: true})
+	c, _ := db.UpsertNode(models.Node{Name: "c", APIAddr: "10.7.0.3:10085", Enabled: true})
+
+	if err := db.SetUserNodes(u.ID, []int64{a, b}); err != nil {
+		t.Fatalf("SetUserNodes: %v", err)
+	}
+	ids, _ := db.ListNodeIDsForUser(u.ID)
+	if len(ids) != 2 {
+		t.Fatalf("after first set: got %v, want 2 ids", ids)
+	}
+
+	// Replace with a different set — old placements must be dropped, not merged.
+	if err := db.SetUserNodes(u.ID, []int64{c}); err != nil {
+		t.Fatalf("SetUserNodes 2: %v", err)
+	}
+	ids, _ = db.ListNodeIDsForUser(u.ID)
+	if len(ids) != 1 || ids[0] != c {
+		t.Errorf("replace failed: got %v, want [%d]", ids, c)
+	}
+
+	// Empty set clears all placements.
+	if err := db.SetUserNodes(u.ID, nil); err != nil {
+		t.Fatalf("SetUserNodes clear: %v", err)
+	}
+	ids, _ = db.ListNodeIDsForUser(u.ID)
+	if len(ids) != 0 {
+		t.Errorf("clear failed: got %v", ids)
+	}
+}
+
+func TestRemoveUserFromNode(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	u, _ := db.CreateUser("bob", "", "tok2", "")
+	a, _ := db.UpsertNode(models.Node{Name: "a", APIAddr: "10.7.0.1:10085", Enabled: true})
+	b, _ := db.UpsertNode(models.Node{Name: "b", APIAddr: "10.7.0.2:10085", Enabled: true})
+	if err := db.SetUserNodes(u.ID, []int64{a, b}); err != nil {
+		t.Fatalf("SetUserNodes: %v", err)
+	}
+
+	if err := db.RemoveUserFromNode(u.ID, a); err != nil {
+		t.Fatalf("RemoveUserFromNode: %v", err)
+	}
+	ids, _ := db.ListNodeIDsForUser(u.ID)
+	if len(ids) != 1 || ids[0] != b {
+		t.Errorf("got %v, want [%d]", ids, b)
+	}
+	// Removing a non-placement is a no-op.
+	if err := db.RemoveUserFromNode(u.ID, a); err != nil {
+		t.Errorf("removing absent placement should be no-op: %v", err)
+	}
+}
+
+func TestListNodesForUser(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	u, _ := db.CreateUser("carol", "", "tok3", "")
+	a, _ := db.UpsertNode(models.Node{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", PublicHost: "eu1.example.com", PublicPort: 443, Enabled: true})
+	_, _ = db.UpsertNode(models.Node{Name: "eu-2", APIAddr: "10.7.0.2:10085", Enabled: true})
+	if err := db.SetUserNodes(u.ID, []int64{a}); err != nil {
+		t.Fatalf("SetUserNodes: %v", err)
+	}
+
+	nodes, err := db.ListNodesForUser(u.ID)
+	if err != nil {
+		t.Fatalf("ListNodesForUser: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Name != "eu-1" || nodes[0].PublicHost != "eu1.example.com" {
+		t.Errorf("got %+v, want just eu-1 with full fields", nodes)
+	}
+}
+
+func TestEnabledNodeIDs(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	a, _ := db.UpsertNode(models.Node{Name: "a", APIAddr: "10.7.0.1:10085", Enabled: true})
+	_, _ = db.UpsertNode(models.Node{Name: "b", APIAddr: "10.7.0.2:10085", Enabled: false})
+	c, _ := db.UpsertNode(models.Node{Name: "c", APIAddr: "10.7.0.3:10085", Enabled: true})
+
+	ids, err := db.EnabledNodeIDs()
+	if err != nil {
+		t.Fatalf("EnabledNodeIDs: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("got %v, want 2 enabled ids", ids)
+	}
+	set := map[int64]bool{ids[0]: true, ids[1]: true}
+	if !set[a] || !set[c] {
+		t.Errorf("expected enabled a,c; got %v", ids)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -95,8 +95,11 @@ type InboundSpec struct {
 
 // CreateUserRequest is the API request body for creating a user
 type CreateUserRequest struct {
-	Username string         `json:"username"`
-	Inbounds []InboundSpec  `json:"inbounds,omitempty"` // Optional: inbounds to add user to. If empty, uses api_user_inbound_tag from config.
+	Username string        `json:"username"`
+	Inbounds []InboundSpec `json:"inbounds,omitempty"` // Optional: inbounds to add user to. If empty, uses api_user_inbound_tag from config.
+	// Nodes optionally places the user on specific nodes by name (multi-node
+	// only). Empty => all enabled nodes (default policy). Ignored single-node.
+	Nodes []string `json:"nodes,omitempty"`
 }
 
 // SubURLs holds all subscription URL variants for a user.


### PR DESCRIPTION
Part of the multi-node design (#100). **Phase 4a** of `docs/multi-node-design.md` §6.2 — the admin API to view the topology and manage per-user node placement. (Phase 4b will add per-node `MultiSyncStatus` + the remote reconcile loop.)

## Endpoints
- `GET /api/nodes` — list the node topology. **Read-only**: node definitions are config-managed and reconciled at startup (§5), so there is deliberately **no** `POST/DELETE /api/nodes` (an API-created node would be disabled on the next reconcile — a footgun).
- `GET /api/users/{id}/nodes` — a user's placements.
- `POST /api/users/{id}/nodes` `{"nodes":["eu-1","eu-2"]}` — replace placement.
- `DELETE /api/users/{id}/nodes/{nodeName}` — drop one placement.
- `POST /api/users` accepts optional `"nodes":[...]` — empty → all enabled nodes (default policy §11); explicit → that subset. Names validated **before** the user is created.

Mutations return **400 when multi-node isn't configured**; unknown node names → 400.

## Why placement is a pure `user_nodes` write
Placement only affects **which node endpoints appear in a user's subscription** — provisioning already fans out to every node (Phase 2). So these handlers don't re-provision anything; they just edit `user_nodes`, which the Phase 3 generator reads.

## DB
`SetUserNodes` (transactional replace), `RemoveUserFromNode`, `ListNodesForUser` (full rows via join), `EnabledNodeIDs`.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race -count=1` — all green
- [x] `golangci-lint` (Test + Security `-E gosec -E misspell -E revive`), `staticcheck`, `gosec`, `go mod tidy` — 0 issues / no diff
- [x] DB tests: SetUserNodes replace+clear, RemoveUserFromNode (+no-op), ListNodesForUser, EnabledNodeIDs (excludes disabled)
- [x] HTTP tests (admin-authed via router): list nodes; set+get placement; unknown-node 400; **placement rejected 400 in single-node**; delete placement; create-user default → all enabled nodes; create-user explicit subset; create-user unknown node → 400