### PR TITLE
feat(multi-node): per-node reconcile loop + status — Phase 4b

### DIFF
--- a/internal/api/nodes.go
+++ b/internal/api/nodes.go
@@ -1,15 +1,18 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/alchemylink/raven-subscribe/internal/models"
+	"github.com/alchemylink/raven-subscribe/internal/xray"
 )
 
 // expandClientsForNodes turns a user's per-inbound client list into a
@@ -225,4 +228,145 @@ func (s *Server) placeUserOnNodes(userID int64, names []string) error {
 		}
 	}
 	return s.db.SetUserNodes(userID, ids)
+}
+
+// ── Per-node reconcile + status (Phase 4b, §6.4) ──────────────────────────────
+
+// isBenignAddExists reports whether a gRPC AddUser error is the idempotent
+// "already exists" reply (same idiom as api/fallback.go).
+func isBenignAddExists(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "exist")
+}
+
+// nodeSyncStatus is the per-node reconcile outcome surfaced additively on
+// /api/sync/status. gRPC-added users are in-memory only, so a remote node
+// restart empties its runtime set until the next reconcile re-adds them; this
+// makes the reconcile a recovery mechanism, not just drift insurance.
+type nodeSyncStatus struct {
+	Reachable       bool      `json:"reachable"`
+	LastApplyOK     bool      `json:"last_apply_ok"`
+	UsersTarget     int       `json:"users_target"`  // users the DB says belong on the node
+	UsersPresent    int       `json:"users_present"` // users the node reports at reconcile time
+	ApplyErrors     int       `json:"apply_errors"`
+	LastReconcileAt time.Time `json:"last_reconcile_at"`
+	LastError       string    `json:"last_error,omitempty"`
+}
+
+// ReconcileNodesLoop periodically re-applies DB placement onto every enabled
+// node over gRPC. Multi-node only; a no-op (returns immediately) in single-node
+// mode, so existing deployments are unaffected. Runs an immediate pass on
+// start, then every interval.
+func (s *Server) ReconcileNodesLoop(ctx context.Context, interval time.Duration) {
+	if len(s.cfg.Nodes) == 0 || interval <= 0 {
+		return
+	}
+	log.Printf("INFO multi-node reconcile loop: interval %s", interval)
+	s.reconcileNodesOnce()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.reconcileNodesOnce()
+		}
+	}
+}
+
+// reconcileNodesOnce runs one add-only reconcile pass across all enabled nodes.
+// For each node it reads the runtime "have" set (GetInboundUsers), computes the
+// "want" set from placement + credentials, and re-adds any missing users. It
+// never removes users: removal would risk dropping legitimately config-loaded
+// users, and node-restart recovery (the point of the loop) only needs adds.
+func (s *Server) reconcileNodesOnce() {
+	nodes, err := s.db.ListNodes()
+	if err != nil {
+		log.Printf("WARN multi-node reconcile: list nodes: %v", err)
+		return
+	}
+	for _, n := range nodes {
+		if !n.Enabled {
+			continue
+		}
+		s.reconcileOneNode(n)
+	}
+}
+
+func (s *Server) reconcileOneNode(n models.Node) {
+	st := nodeSyncStatus{LastReconcileAt: time.Now().UTC()}
+
+	want, err := s.db.ListWantedClientsForNode(n.ID, n.InboundTag)
+	if err != nil {
+		st.LastError = "list wanted: " + err.Error()
+		s.storeNodeStatus(n.Name, st)
+		return
+	}
+	st.UsersTarget = len(want)
+
+	have, err := xray.GetInboundUsersViaAPI(n.APIAddr, n.InboundTag)
+	if err != nil {
+		// Node unreachable (down, WG flap). Report and move on; the next pass
+		// recovers it. UsersTarget is still meaningful (from the DB).
+		st.Reachable = false
+		st.LastError = err.Error()
+		s.storeNodeStatus(n.Name, st)
+		return
+	}
+	st.Reachable = true
+	st.UsersPresent = len(have)
+
+	applyErrors := 0
+	for _, w := range clientsToAdd(want, have) {
+		if err := xray.AddExistingClientToInboundViaAPI(n.APIAddr, n.InboundTag, w.Email, w.ClientConfig); err != nil && !isBenignAddExists(err) {
+			applyErrors++
+			log.Printf("WARN multi-node reconcile: node %q re-add %s: %v", n.Name, sanitizeLogField(w.Email), err)
+		}
+	}
+	st.ApplyErrors = applyErrors
+	st.LastApplyOK = applyErrors == 0
+	s.storeNodeStatus(n.Name, st)
+}
+
+// clientsToAdd returns the wanted clients missing from the node's runtime
+// "have" set — the add-only diff. Pure function, no I/O.
+func clientsToAdd(want []models.WantedClient, have []string) []models.WantedClient {
+	haveSet := make(map[string]bool, len(have))
+	for _, e := range have {
+		haveSet[e] = true
+	}
+	var add []models.WantedClient
+	for _, w := range want {
+		if !haveSet[w.Email] {
+			add = append(add, w)
+		}
+	}
+	return add
+}
+
+func (s *Server) storeNodeStatus(name string, st nodeSyncStatus) {
+	s.nodeStatusMu.Lock()
+	if s.nodeStatus == nil {
+		s.nodeStatus = map[string]nodeSyncStatus{}
+	}
+	s.nodeStatus[name] = st
+	s.nodeStatusMu.Unlock()
+}
+
+// snapshotNodeStatus returns a copy of the per-node status map, or nil in
+// single-node mode (so the field is omitted from /api/sync/status).
+func (s *Server) snapshotNodeStatus() map[string]nodeSyncStatus {
+	if len(s.cfg.Nodes) == 0 {
+		return nil
+	}
+	s.nodeStatusMu.Lock()
+	defer s.nodeStatusMu.Unlock()
+	if len(s.nodeStatus) == 0 {
+		return nil
+	}
+	out := make(map[string]nodeSyncStatus, len(s.nodeStatus))
+	for k, v := range s.nodeStatus {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/api/nodes_api_test.go
+++ b/internal/api/nodes_api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alchemylink/raven-subscribe/internal/config"
 	"github.com/alchemylink/raven-subscribe/internal/database"
@@ -177,5 +179,86 @@ func TestCreateUser_UnknownNodeIs400(t *testing.T) {
 	srv.Router().ServeHTTP(rec, adminReq(http.MethodPost, "/api/users", `{"username":"grace@z.com","nodes":["nope"]}`))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("unknown node on create should be 400, got %d", rec.Code)
+	}
+}
+
+func TestClientsToAdd(t *testing.T) {
+	want := []models.WantedClient{
+		{Email: "a@z", ClientConfig: "{}"},
+		{Email: "b@z", ClientConfig: "{}"},
+		{Email: "c@z", ClientConfig: "{}"},
+	}
+	// b already present on the node.
+	add := clientsToAdd(want, []string{"b@z"})
+	if len(add) != 2 {
+		t.Fatalf("expected 2 to add, got %d", len(add))
+	}
+	got := map[string]bool{add[0].Email: true, add[1].Email: true}
+	if !got["a@z"] || !got["c@z"] || got["b@z"] {
+		t.Errorf("wrong add set: %+v", add)
+	}
+	// All present → nothing to add.
+	if n := clientsToAdd(want, []string{"a@z", "b@z", "c@z"}); len(n) != 0 {
+		t.Errorf("expected empty add, got %+v", n)
+	}
+}
+
+func TestSyncStatus_SingleNodeOmitsNodes(t *testing.T) {
+	srv, _ := testServer(t) // no cfg.Nodes
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodGet, "/api/sync/status", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := m["nodes"]; ok {
+		t.Error("single-node /api/sync/status must omit the nodes field")
+	}
+	// Flat fields still present (unchanged shape).
+	if _, ok := m["probe_ok"]; !ok {
+		t.Error("expected flat SyncStatus fields (probe_ok) to remain")
+	}
+}
+
+func TestSyncStatus_MultiNodeIncludesNodes(t *testing.T) {
+	srv, _ := multiNodeServer(t, twoNodes())
+	// Simulate a completed reconcile pass.
+	srv.storeNodeStatus("eu-1", nodeSyncStatus{Reachable: true, LastApplyOK: true, UsersTarget: 3, UsersPresent: 3})
+	srv.storeNodeStatus("eu-2", nodeSyncStatus{Reachable: false, LastError: "connection refused", UsersTarget: 3})
+
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, adminReq(http.MethodGet, "/api/sync/status", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	var resp struct {
+		ProbeOK bool                      `json:"probe_ok"`
+		Nodes   map[string]nodeSyncStatus `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Nodes) != 2 {
+		t.Fatalf("expected 2 node statuses, got %d", len(resp.Nodes))
+	}
+	if !resp.Nodes["eu-1"].Reachable || resp.Nodes["eu-2"].Reachable {
+		t.Errorf("node reachability wrong: %+v", resp.Nodes)
+	}
+	if resp.Nodes["eu-2"].LastError == "" {
+		t.Error("expected eu-2 to carry the unreachable error")
+	}
+}
+
+func TestReconcileNodesLoop_SingleNodeReturnsImmediately(t *testing.T) {
+	srv, _ := testServer(t) // no nodes
+	done := make(chan struct{})
+	go func() { srv.ReconcileNodesLoop(context.Background(), time.Second); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReconcileNodesLoop should return immediately in single-node mode")
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -53,11 +53,15 @@ type Server struct {
 	// monitoring can alert on users hitting a disabled fallback (a forgotten
 	// sanitization window). Resets on restart — alert on increase(), not value.
 	fallbackDenied atomic.Int64
+	// nodeStatus holds the last multi-node reconcile outcome per node name,
+	// surfaced additively on /api/sync/status. Nil/empty in single-node mode.
+	nodeStatusMu sync.Mutex
+	nodeStatus   map[string]nodeSyncStatus
 }
 
 // NewServer creates a new Server with the given config, database, and syncer.
 func NewServer(cfg *config.Config, db *database.DB, syncer Syncer) *Server {
-	return &Server{cfg: cfg, db: db, syncer: syncer, admin: buildAdmin(cfg)}
+	return &Server{cfg: cfg, db: db, syncer: syncer, admin: buildAdmin(cfg), nodeStatus: map[string]nodeSyncStatus{}}
 }
 
 // buildAdmin selects the engine write backend:
@@ -1633,7 +1637,16 @@ func (s *Server) triggerSync(w http.ResponseWriter, _ *http.Request) {
 //
 // GET /api/sync/status
 func (s *Server) handleSyncStatus(w http.ResponseWriter, _ *http.Request) {
-	jsonOK(w, s.syncer.Status())
+	// Embed the existing flat SyncStatus (unchanged for single-node consumers)
+	// and add an optional per-node map in multi-node mode.
+	resp := struct {
+		syncer.SyncStatus
+		Nodes map[string]nodeSyncStatus `json:"nodes,omitempty"`
+	}{
+		SyncStatus: s.syncer.Status(),
+		Nodes:      s.snapshotNodeStatus(),
+	}
+	jsonOK(w, resp)
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1160,6 +1160,35 @@ func (db *DB) RemoveUserFromNode(userID, nodeID int64) error {
 	return err
 }
 
+// ListWantedClientsForNode returns the (email, credential) pairs the reconcile
+// expects on a node: enabled users placed on nodeID who hold an enabled
+// credential for inboundTag. This is the "want" set for the node's runtime
+// "have" set (GetInboundUsers).
+func (db *DB) ListWantedClientsForNode(nodeID int64, inboundTag string) ([]models.WantedClient, error) {
+	rows, err := db.conn.Query(
+		`SELECT u.email, uc.client_config
+		 FROM user_nodes un
+		 JOIN users u        ON u.id = un.user_id
+		 JOIN inbounds i     ON i.tag = ?
+		 JOIN user_clients uc ON uc.user_id = u.id AND uc.inbound_id = i.id
+		 WHERE un.node_id = ? AND u.enabled = 1 AND uc.enabled = 1
+		 ORDER BY u.email`, inboundTag, nodeID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []models.WantedClient
+	for rows.Next() {
+		var w models.WantedClient
+		if err := rows.Scan(&w.Email, &w.ClientConfig); err != nil {
+			return nil, err
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
 // EnabledNodeIDs returns the ids of all enabled nodes, ordered by name.
 func (db *DB) EnabledNodeIDs() ([]int64, error) {
 	rows, err := db.conn.Query(`SELECT id FROM nodes WHERE enabled = 1 ORDER BY name`)

--- a/internal/database/nodes_test.go
+++ b/internal/database/nodes_test.go
@@ -310,3 +310,51 @@ func TestEnabledNodeIDs(t *testing.T) {
 		t.Errorf("expected enabled a,c; got %v", ids)
 	}
 }
+
+func TestListWantedClientsForNode(t *testing.T) {
+	db, cleanup := testDB(t)
+	defer cleanup()
+
+	// Inbound + node both on tag "vless-in".
+	ibID, err := db.UpsertInbound("vless-in", "vless", 443, "f.json", `{"tag":"vless-in"}`)
+	if err != nil {
+		t.Fatalf("UpsertInbound: %v", err)
+	}
+	nodeID, _ := db.UpsertNode(models.Node{Name: "eu-1", APIAddr: "10.7.0.1:10085", InboundTag: "vless-in", Enabled: true})
+
+	// alice: enabled, placed, has credential → wanted.
+	alice, _ := db.CreateUser("alice", "", "t-alice", "")
+	if err := db.UpsertUserClient(alice.ID, ibID, `{"id":"a"}`); err != nil {
+		t.Fatalf("UpsertUserClient alice: %v", err)
+	}
+	if err := db.AssignUserToNodes(alice.ID, []int64{nodeID}); err != nil {
+		t.Fatalf("AssignUserToNodes alice: %v", err)
+	}
+
+	// bob: placed + credential but DISABLED → excluded.
+	bob, _ := db.CreateUser("bob", "", "t-bob", "")
+	_ = db.UpsertUserClient(bob.ID, ibID, `{"id":"b"}`)
+	_ = db.AssignUserToNodes(bob.ID, []int64{nodeID})
+	if err := db.SetUserEnabled(bob.ID, false); err != nil {
+		t.Fatalf("disable bob: %v", err)
+	}
+
+	// carol: has credential but NOT placed on the node → excluded.
+	carol, _ := db.CreateUser("carol", "", "t-carol", "")
+	_ = db.UpsertUserClient(carol.ID, ibID, `{"id":"c"}`)
+
+	// dave: placed but NO credential for the inbound → excluded.
+	dave, _ := db.CreateUser("dave", "", "t-dave", "")
+	_ = db.AssignUserToNodes(dave.ID, []int64{nodeID})
+
+	want, err := db.ListWantedClientsForNode(nodeID, "vless-in")
+	if err != nil {
+		t.Fatalf("ListWantedClientsForNode: %v", err)
+	}
+	if len(want) != 1 {
+		t.Fatalf("expected only alice wanted, got %d: %+v", len(want), want)
+	}
+	if want[0].Email != "alice" || want[0].ClientConfig != `{"id":"a"}` {
+		t.Errorf("wrong wanted client: %+v", want[0])
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -60,6 +60,15 @@ type Node struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
+// WantedClient is one (identity, credential) the multi-node reconcile expects
+// to exist on a node: an enabled user placed on the node who holds an enabled
+// credential for the node's inbound_tag. Used as the "want" set against the
+// node's runtime "have" set from GetInboundUsers.
+type WantedClient struct {
+	Email        string
+	ClientConfig string
+}
+
 // UserClient maps a user to their credentials in a specific inbound
 type UserClient struct {
 	ID           int64  `json:"id"`

--- a/internal/xray/apiclient.go
+++ b/internal/xray/apiclient.go
@@ -326,6 +326,42 @@ func RemoveInboundViaAPI(apiAddr, tag string) error {
 	return nil
 }
 
+// GetInboundUsersViaAPI returns the emails of every user currently registered
+// on the given inbound at the running Xray instance (HandlerService
+// GetInboundUsers with an empty email = all users). This is the runtime "have"
+// set for multi-node reconcile: because gRPC-added users are in-memory only, a
+// node restart empties this list until the reconcile loop re-adds them.
+func GetInboundUsersViaAPI(apiAddr, tag string) ([]string, error) {
+	if apiAddr == "" {
+		return nil, fmt.Errorf("xray_api_addr required")
+	}
+	if strings.TrimSpace(tag) == "" {
+		return nil, fmt.Errorf("tag required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), apiDialTimeout)
+	defer cancel()
+
+	conn, err := dialXrayAPI(apiAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	client := command.NewHandlerServiceClient(conn)
+	resp, err := client.GetInboundUsers(ctx, &command.GetInboundUserRequest{Tag: tag})
+	if err != nil {
+		return nil, fmt.Errorf("get inbound users: %w", err)
+	}
+	emails := make([]string, 0, len(resp.GetUsers()))
+	for _, u := range resp.GetUsers() {
+		if e := strings.TrimSpace(u.GetEmail()); e != "" {
+			emails = append(emails, e)
+		}
+	}
+	return emails, nil
+}
+
 // clientMapToProtocolUser converts a client map (from build*Client) to protocol.User.
 func clientMapToProtocolUser(protocolName string, client map[string]interface{}, email string) (*protocol.User, error) {
 	proto := strings.ToLower(protocolName)

--- a/main.go
+++ b/main.go
@@ -93,6 +93,11 @@ func main() {
 	// See internal/api/fallback.go ReconcileKillSwitchLoop for the full rationale.
 	go srv.ReconcileKillSwitchLoop(syncCtx, time.Duration(cfg.KillSwitchReconcileInterval)*time.Second)
 
+	// Multi-node reconcile: re-apply DB placement onto remote gRPC nodes every
+	// sync interval (recovery after a node restart wipes its in-memory users).
+	// No-op in single-node mode.
+	go srv.ReconcileNodesLoop(syncCtx, time.Duration(cfg.SyncInterval)*time.Second)
+
 	// ── HTTP Server ─────────────────────────────────────────────────────────
 	httpServer := &http.Server{
 		Addr:         cfg.ListenAddr,


### PR DESCRIPTION
Part of the multi-node design (#100). **Phase 4b** of `docs/multi-node-design.md` §6.4 — remote-node durability + per-node health. Completes Phase 4. All of it is **dormant in single-node mode** (gated on `len(cfg.Nodes) > 0`).

## What's in
- **`xray.GetInboundUsersViaAPI(apiAddr, tag)`** wraps `HandlerService.GetInboundUsers` — a node's runtime "have" set. gRPC-added users are in-memory only, so a remote node restart empties this until the reconcile re-adds them (why the loop is a *recovery* mechanism, not just drift insurance).
- **DB `ListWantedClientsForNode(nodeID, tag)`** → the "want" set: enabled users placed on the node holding an enabled credential for its `inbound_tag`.
- **Reconcile loop (add-only)** — `ReconcileNodesLoop` runs every sync interval (immediate first pass). Per enabled node it diffs want vs have and re-adds the missing via `AddExistingClient`, swallowing benign "already exists". It **never removes** — removal could drop legitimately config-loaded users, and node-restart recovery only needs adds. The pure diff is `clientsToAdd()`, unit-tested without gRPC.
- **Per-node status** (`reachable` / `last_apply_ok` / `users_target` / `users_present` / `apply_errors` / `last_error`) recorded each pass, surfaced **additively** on `/api/sync/status`: the flat `SyncStatus` is embedded unchanged and an optional `nodes` map is added — single-node responses are byte-identical, existing dashboard consumers unaffected.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race -count=1` — all green
- [x] `golangci-lint` (Test + Security `-E gosec -E misspell -E revive`), `staticcheck`, `gosec`, `go mod tidy` — 0 issues / no diff
- [x] DB test: `ListWantedClientsForNode` filters correctly (excludes disabled user, unplaced user, and user without a credential for the tag)
- [x] api tests: `clientsToAdd` diff (present skipped, all-present → empty); `/api/sync/status` **single-node omits `nodes`** + keeps flat fields; **multi-node includes `nodes`** with per-node reachable/error; `ReconcileNodesLoop` returns immediately in single-node

Remaining for the epic: **Phase 5** (WG-bound gRPC default + optional mTLS, README/INSTALL multi-node section, Ansible role).