### PR TITLE
feat(multi-node): optional mTLS for node gRPC dials (Phase 5)

### DIFF
--- a/docs/multi-node-design.md
+++ b/docs/multi-node-design.md
@@ -82,7 +82,19 @@ gRPC-слой как есть и не тронув локальный путь.
     },
     { "name": "eu-2", "api_addr": "10.7.0.2:10085",
       "inbound_tag": "vless-reality-in", "public_host": "eu2.example.com",
-      "public_port": 443, "enabled": true }
+      "public_port": 443, "enabled": true },
+
+    { "name": "eu-3",                      // нода БЕЗ WG → gRPC по публичному адресу под mTLS
+      "api_addr": "203.0.113.7:10085",     // публичный адрес разрешён, т.к. есть tls-блок (§7)
+      "inbound_tag": "vless-reality-in", "public_host": "eu3.example.com",
+      "public_port": 443, "enabled": true,
+      "tls": {                             // ОПЦИОНАЛЬНО, mTLS на gRPC-дайал к этой ноде
+        "ca_cert":     "/etc/raven/pki/node-ca.pem",   // CA, подписавший server-cert ноды
+        "client_cert": "/etc/raven/pki/raven-client.pem",
+        "client_key":  "/etc/raven/pki/raven-client.key",
+        "server_name": "eu-3.internal"     // пусто → host из api_addr
+      }
+    }
   ]
 }
 ```
@@ -94,8 +106,9 @@ gRPC-слой как есть и не тронув локальный путь.
 - `nodes` задан → legacy-поля игнорируются для провижининга (но `server_host`
   остаётся дефолтом для `HostForInbound`/балансера, если у ноды пусто).
 - Валидация: `name` уникален и непустой; `api_addr` непуст; при `mode="grpc"`
-  адрес обязан быть в private-диапазоне ИЛИ явный флаг `allow_public_grpc:true`
-  (анти-footgun против plaintext-по-интернету, §7).
+  адрес обязан быть в private-диапазоне ИЛИ иметь `tls`-блок (mTLS) ИЛИ явный
+  флаг `allow_public_grpc:true` (анти-footgun против plaintext-по-интернету, §7).
+  `tls`-блок, если задан, требует `ca_cert`+`client_cert`+`client_key`.
 
 ## 5. Модель БД
 
@@ -264,25 +277,33 @@ failures remain visible».
 
 ## 7. Security (блокер, не TODO)
 
-`dialXrayAPI` использует `insecure.NewCredentials()` — **plaintext gRPC**.
-HandlerService = полный контроль над юзерами/инбаундами. По интернету без
-auth/TLS это критическая дыра: кто угодно в сети добавит/удалит юзеров на
-всех нодах.
+HandlerService = полный контроль над юзерами/инбаундами (и, без per-RPC ACL,
+над inbound/outbound — §13). По интернету без auth/TLS это критическая дыра:
+кто угодно в сети добавит/удалит юзеров на всех нодах. **Multi-node нельзя
+выпускать с plaintext gRPC по публичной сети.** Транспорт выбирается
+**per-node по `api_addr`** в единственном chokepoint `dialXrayAPI`
+(`resolveCredentials`): нода из mTLS-мапы → TLS, любой другой адрес
+(WG/loopback) → plaintext. Два пути, в порядке предпочтения:
 
-**Multi-node нельзя выпускать с plaintext gRPC по публичной сети.** Два пути,
-в порядке предпочтения:
-
-1. **gRPC только по WireGuard** (рекомендация и для нашего прода, и для доки
-   комьюнити). Xray API слушает на WG-адресе ноды; шифрование и взаимная
-   аутентификация — на уровне WG. gRPC остаётся «insecure», но недостижим
-   извне. Идеально ложится на нашу существующую EU/RU mesh
-   (`f3_second_ru_research`), не требует gRPC-TLS-обвязки.
-2. **mTLS на gRPC** — для тех, у кого нет WG. Больше кода (cert provisioning).
-   Реализуется заменой `insecure.NewCredentials()` на
-   `credentials.NewTLS(...)` в `dialXrayAPI` + per-node cert в конфиге.
+1. **gRPC только по WireGuard (дефолт-рекомендация).** Xray API слушает на
+   WG-адресе ноды; шифрование и взаимная аутентификация — на уровне WG. gRPC
+   остаётся plaintext, но недостижим извне туннеля. Ложится на нашу
+   существующую EU/RU mesh (`f3_second_ru_research`), не требует gRPC-TLS-обвязки
+   и ротации сертов. Конфиг: `api_addr` в private-диапазоне, без `tls`-блока —
+   валидация проходит по `isPrivateHostPort`.
+2. **mTLS на gRPC (для нод без WG).** Реализовано (Фаза 5): опциональный
+   per-node `tls`-блок `{ca_cert, client_cert, client_key, server_name?}`.
+   Raven — TLS-клиент: предъявляет client-cert, проверяет server-cert по CA;
+   `server_name` пусто → host из `api_addr`; форсируется TLS 1.3. Серты читаются
+   **один раз на старте** (`main.configureNodeCredentials` → `xray.BuildTLSCredentials`
+   + `SetNodeCredentials`), **fail-closed** — битый cert = fatal, никогда не
+   молчаливый откат на plaintext против публичного адреса. Cert-provisioning
+   (server-cert + clientAuth на Xray-side) делает Ansible-роль ноды.
 
 Анти-footgun в `config.Load` (§4): `mode="grpc"` с публичным `api_addr` и без
-явного `allow_public_grpc:true` → ошибка старта с объяснением.
+защиты → ошибка старта. Guard снимается **любым** из: private/WG-адрес,
+`tls`-блок (mTLS сам по себе — шифрование+аутентификация), или явный
+`allow_public_grpc:true` (escape-hatch для внешней mTLS-терминации sidecar'ом).
 
 ## 8. SSH/rsync деплой — механизм durability, не просто опция
 
@@ -355,9 +376,12 @@ remote-нод; admin-эндпоинты `/api/nodes`.
 не роняет sync остальных.
 
 ### Фаза 5 — security + docs + Ansible
-WG-bound gRPC как дефолт; `allow_public_grpc` guard; опциональный mTLS;
-README + INSTALL multi-node секция; Ansible-роль для homogeneous-нод
-(cross-check с Raven-server-install). **Риск:** низкий.
+WG-bound gRPC как дефолт (рекомендация); `allow_public_grpc` guard; опциональный
+mTLS. **mTLS — ГОТОВО** (per-node `tls`-блок, §7): `dialXrayAPI` резолвит creds
+per-`api_addr`, WG/loopback остаётся plaintext, mTLS снимает public-grpc guard,
+fail-closed на старте, TLS 1.3. Остаётся: README + INSTALL multi-node секция;
+Ansible-роль для homogeneous-нод (cross-check с Raven-server-install) —
+provision server-cert + `clientAuth` на Xray gRPC-инбаунде. **Риск:** низкий.
 
 ## 10. Приёмка (инвариант «не сломали subscriber»)
 
@@ -370,9 +394,12 @@ README + INSTALL multi-node секция; Ansible-роль для homogeneous-н
 - При `nodes=[A,B]` гомогенных:
   - юзер, размещённый на A и B, получает балансер из 2 outbound-ов;
   - падение B → юзер всё ещё рабочий через A; `status.nodes["eu-2"].reachable=false`;
-  - plaintext gRPC на публичный адрес без `allow_public_grpc` → отказ старта.
-- `grep -rn 'insecure.NewCredentials' internal/xray` присутствует только за
-  WG-guard или mTLS-веткой (security-ревью Фазы 5).
+  - plaintext gRPC на публичный адрес без `tls`/`allow_public_grpc` → отказ старта;
+  - нода с `tls`-блоком и публичным `api_addr` → старт разрешён (mTLS = guard);
+  - `tls`-блок с битым/отсутствующим cert → fatal на старте (fail-closed).
+- `insecure.NewCredentials()` живёт только в `resolveCredentials` (дефолт для
+  WG/loopback-нод); все mTLS-ноды дайлятся через `credentials.NewTLS` из
+  `SetNodeCredentials`-мапы (security-ревью Фазы 5).
 
 ## 11. Открытые вопросы
 

--- a/internal/api/hysteria_test.go
+++ b/internal/api/hysteria_test.go
@@ -65,7 +65,7 @@ func TestHysteriaInMainSub(t *testing.T) {
 	xID, _ := srv.db.UpsertInbound("vless-xhttp-v2-in", "vless", 443, "210.json",
 		`{"tag":"vless-xhttp-v2-in","protocol":"vless","port":443,"streamSettings":{"network":"xhttp","security":"reality","realitySettings":{"serverNames":["www.python.org"],"publicKey":"testpublickey12345678901234567890123456789012","shortIds":["ab"]},"xhttpSettings":{"mode":"packet-up","host":"www.python.org","path":"/x"}}}`)
 	_ = srv.db.UpsertUserClient(u.ID, xID, `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision","encryption":"none"}`)
-	hy := &config.HysteriaConfig{Enabled: true, Host: "zirgate.com", Port: 47014, ObfsType: "salamander", ObfsPassword: "pw", SNI: "www.python.org", CertPin: "abc"}
+	hy := &config.HysteriaConfig{Enabled: true, Host: "example.com", Port: 47014, ObfsType: "salamander", ObfsPassword: "pw", SNI: "www.python.org", CertPin: "abc"}
 
 	get := func() string {
 		req := httptest.NewRequest(http.MethodGet, "/sub/t-alice/links.txt", nil)
@@ -84,7 +84,7 @@ func TestHysteriaInMainSub(t *testing.T) {
 		hy.InMainSub = true
 		srv.cfg.Hysteria = hy
 		body := get()
-		if !strings.Contains(body, "hysteria2://t-alice@zirgate.com:47014") {
+		if !strings.Contains(body, "hysteria2://t-alice@example.com:47014") {
 			t.Errorf("hy2 URI missing from links: %s", body)
 		}
 		if !strings.Contains(body, "vless://") {
@@ -106,8 +106,8 @@ func TestHysteriaPerUserGate(t *testing.T) {
 		`{"tag":"vless-xhttp-v2-in","protocol":"vless","port":443,"streamSettings":{"network":"xhttp","security":"reality","realitySettings":{"serverNames":["www.python.org"],"publicKey":"testpublickey12345678901234567890123456789012","shortIds":["ab"]},"xhttpSettings":{"mode":"packet-up","host":"www.python.org","path":"/x"}}}`)
 	_ = srv.db.UpsertUserClient(u.ID, xID, `{"protocol":"vless","id":"uuid1","flow":"xtls-rprx-vision","encryption":"none"}`)
 	srv.cfg.Hysteria = &config.HysteriaConfig{
-		Enabled: true, Host: "zirgate.com", Port: 47014,
-		ObfsType: "salamander", ObfsPassword: "obfspw", SNI: "hy2.zirgate.com",
+		Enabled: true, Host: "example.com", Port: 47014,
+		ObfsType: "salamander", ObfsPassword: "obfspw", SNI: "hy2.example.com",
 		InMainSub: true,
 	}
 
@@ -166,7 +166,7 @@ func TestHysteriaSub(t *testing.T) {
 	defer cleanup()
 	hyTestUser(t, srv)
 	srv.cfg.Hysteria = &config.HysteriaConfig{
-		Enabled: true, Host: "zirgate.com", Port: 47014,
+		Enabled: true, Host: "example.com", Port: 47014,
 		ObfsType: "salamander", ObfsPassword: "obfspw", SNI: "www.python.org",
 		CertPin: "593c5be48dbc7697098beba3d3c326bbd722ca2a58b47a9abd69ab71f0345e3b",
 	}
@@ -179,7 +179,7 @@ func TestHysteriaSub(t *testing.T) {
 			t.Fatalf("got %d, want 200 (%s)", rec.Code, rec.Body.String())
 		}
 		uri := rec.Body.String()
-		for _, want := range []string{"hysteria2://t-alice@zirgate.com:47014", "obfs=salamander", "obfs-password=obfspw", "sni=www.python.org", "pinSHA256=593c5be4", "insecure=1"} {
+		for _, want := range []string{"hysteria2://t-alice@example.com:47014", "obfs=salamander", "obfs-password=obfspw", "sni=www.python.org", "pinSHA256=593c5be4", "insecure=1"} {
 			if !strings.Contains(uri, want) {
 				t.Errorf("URI missing %q: %s", want, uri)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,29 @@ type NodeConfig struct {
 	// requirement. Set only when you have mTLS or another out-of-band guard on
 	// a publicly reachable HandlerService.
 	AllowPublicGRPC bool `json:"allow_public_grpc,omitempty"`
+	// TLS enables mutual-TLS on the gRPC dial to this node (§9). Optional; nil
+	// means plaintext — the recommended posture for a node whose gRPC is bound to
+	// a WireGuard/private address. Configure it when you must reach the
+	// HandlerService over a public api_addr: mTLS then both encrypts the channel
+	// and satisfies the public-grpc anti-footgun guard (no allow_public_grpc
+	// needed). The certificate files are read at startup by main, not here.
+	TLS *NodeTLS `json:"tls,omitempty"`
+}
+
+// NodeTLS configures mutual-TLS for the control plane's gRPC dial to a node.
+// raven-subscribe acts as the TLS client: it presents ClientCert/ClientKey and
+// verifies the node's server certificate against CACert. All three paths are
+// required when the block is present.
+type NodeTLS struct {
+	// CACert is the path to the PEM CA bundle that signed the node's server cert.
+	CACert string `json:"ca_cert"`
+	// ClientCert is the path to raven's client certificate PEM.
+	ClientCert string `json:"client_cert"`
+	// ClientKey is the path to raven's client private-key PEM.
+	ClientKey string `json:"client_key"`
+	// ServerName overrides the expected certificate SAN. Empty defaults to the
+	// host portion of the node's api_addr.
+	ServerName string `json:"server_name,omitempty"`
 }
 
 // NodeDeploy configures how a node receives config for durability across
@@ -316,14 +339,22 @@ func validateNodes(nodes []NodeConfig) error {
 		if mode != "grpc" && mode != "ssh_rsync" {
 			return fmt.Errorf("node %q: invalid deploy.mode %q (want grpc|ssh_rsync)", name, mode)
 		}
+		if n.TLS != nil {
+			if strings.TrimSpace(n.TLS.CACert) == "" ||
+				strings.TrimSpace(n.TLS.ClientCert) == "" ||
+				strings.TrimSpace(n.TLS.ClientKey) == "" {
+				return fmt.Errorf("node %q: tls requires ca_cert, client_cert and client_key", name)
+			}
+		}
 		// Anti-footgun (§7): plaintext gRPC HandlerService grants full control
 		// over users/inbounds. Refuse a public api_addr in grpc mode unless the
-		// operator explicitly accepts the risk (they should be fronting it with
-		// mTLS or another guard).
-		if mode == "grpc" && !n.AllowPublicGRPC && !isPrivateHostPort(n.APIAddr) {
+		// operator explicitly accepts the risk — either by fronting it with mTLS
+		// (a tls block, the encrypted+authenticated guard) or by setting
+		// allow_public_grpc to acknowledge some other out-of-band protection.
+		if mode == "grpc" && n.TLS == nil && !n.AllowPublicGRPC && !isPrivateHostPort(n.APIAddr) {
 			return fmt.Errorf("node %q: api_addr %q is not a private/loopback address; "+
-				"bind Xray's gRPC to a WireGuard/private address, or set allow_public_grpc:true "+
-				"if you guard it with mTLS", name, n.APIAddr)
+				"bind Xray's gRPC to a WireGuard/private address, add a tls block to guard it "+
+				"with mTLS, or set allow_public_grpc:true if you guard it another way", name, n.APIAddr)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ import (
 // HysteriaConfig configures the per-user Hysteria2 reserve subscription channel.
 type HysteriaConfig struct {
 	Enabled      bool   `json:"enabled"`
-	Host         string `json:"host"`          // domain clients connect to (relay apex, e.g. zirgate.com)
+	Host         string `json:"host"`          // domain clients connect to (relay apex, e.g. example.com)
 	Port         int    `json:"port"`          // relay UDP port forwarded to the EU hysteria server (e.g. 47014)
 	ObfsType     string `json:"obfs_type"`     // "salamander" (mainstream-client default) or "gecko"
 	ObfsPassword string `json:"obfs_password"` // shared obfs key (server-wide, not per-user)

--- a/internal/config/config_nodes_test.go
+++ b/internal/config/config_nodes_test.go
@@ -121,6 +121,24 @@ func TestValidateNodes(t *testing.T) {
 			nodes:   []NodeConfig{{Name: "eu-1", APIAddr: "203.0.113.5:22", Deploy: &NodeDeploy{Mode: "ssh_rsync"}}},
 			wantErr: false,
 		},
+		{
+			name: "public grpc guarded by mTLS ok (tls satisfies footgun guard)",
+			nodes: []NodeConfig{{Name: "eu-1", APIAddr: "203.0.113.5:10085",
+				TLS: &NodeTLS{CACert: "/e/ca.pem", ClientCert: "/e/c.pem", ClientKey: "/e/c.key"}}},
+			wantErr: false,
+		},
+		{
+			name: "tls block missing ca_cert rejected",
+			nodes: []NodeConfig{{Name: "eu-1", APIAddr: "10.7.0.1:10085",
+				TLS: &NodeTLS{ClientCert: "/e/c.pem", ClientKey: "/e/c.key"}}},
+			wantErr: true,
+		},
+		{
+			name: "tls block missing client_key rejected",
+			nodes: []NodeConfig{{Name: "eu-1", APIAddr: "203.0.113.5:10085",
+				TLS: &NodeTLS{CACert: "/e/ca.pem", ClientCert: "/e/c.pem"}}},
+			wantErr: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/xray/apiclient.go
+++ b/internal/xray/apiclient.go
@@ -20,13 +20,16 @@ import (
 	"github.com/xtls/xray-core/proxy/vless"
 	"github.com/xtls/xray-core/proxy/vmess"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const apiDialTimeout = 10 * time.Second
 
+// dialXrayAPI opens a gRPC client to a node's HandlerService. Transport security
+// is resolved per api_addr: a node configured with mTLS dials over TLS, every
+// other address (WireGuard/loopback, single-node local) dials plaintext. See
+// SetNodeCredentials / resolveCredentials in tls.go.
 func dialXrayAPI(apiAddr string) (*grpc.ClientConn, error) {
-	conn, err := grpc.NewClient(apiAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(apiAddr, grpc.WithTransportCredentials(resolveCredentials(apiAddr)))
 	if err != nil {
 		return nil, fmt.Errorf("dial xray api %s: %w", apiAddr, err)
 	}

--- a/internal/xray/tls.go
+++ b/internal/xray/tls.go
@@ -1,0 +1,69 @@
+package xray
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// nodeCreds maps a node's gRPC api_addr to the transport credentials used to
+// dial it. It is populated once at startup (SetNodeCredentials) from the
+// multi-node TLS config and only ever read afterwards. dialXrayAPI consults it;
+// an api_addr with no entry dials plaintext (insecure) — the correct default
+// for a WireGuard/loopback node and for the legacy single-node local dial.
+var (
+	nodeCredsMu sync.RWMutex
+	nodeCreds   map[string]credentials.TransportCredentials
+)
+
+// SetNodeCredentials installs the per-node transport credentials keyed by
+// api_addr. It replaces any previous set wholesale and is intended to be called
+// exactly once during startup, before the control plane dials any node. Passing
+// nil or an empty map returns every dial to plaintext.
+func SetNodeCredentials(creds map[string]credentials.TransportCredentials) {
+	nodeCredsMu.Lock()
+	defer nodeCredsMu.Unlock()
+	nodeCreds = creds
+}
+
+// resolveCredentials returns the transport credentials to dial apiAddr with,
+// defaulting to plaintext when no mTLS was configured for that address.
+func resolveCredentials(apiAddr string) credentials.TransportCredentials {
+	nodeCredsMu.RLock()
+	defer nodeCredsMu.RUnlock()
+	if c, ok := nodeCreds[apiAddr]; ok {
+		return c
+	}
+	return insecure.NewCredentials()
+}
+
+// BuildTLSCredentials assembles mutual-TLS client credentials for a gRPC dial:
+// it presents the client cert/key and verifies the server against caCertPath.
+// serverName, when non-empty, overrides the SAN the server cert is matched
+// against (otherwise gRPC uses the dial target's host). TLS 1.3 is required.
+func BuildTLSCredentials(caCertPath, clientCertPath, clientKeyPath, serverName string) (credentials.TransportCredentials, error) {
+	// #nosec G304 -- paths come from the operator's own config file, not user input.
+	caPEM, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ca_cert %s: %w", caCertPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("ca_cert %s: no PEM certificates found", caCertPath)
+	}
+	cert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load client keypair (%s / %s): %w", clientCertPath, clientKeyPath, err)
+	}
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		ServerName:   serverName,
+		MinVersion:   tls.VersionTLS13,
+	}), nil
+}

--- a/internal/xray/tls_test.go
+++ b/internal/xray/tls_test.go
@@ -1,0 +1,108 @@
+package xray
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/credentials"
+)
+
+func TestResolveCredentials_DefaultsToInsecure(t *testing.T) {
+	SetNodeCredentials(nil)
+	c := resolveCredentials("10.7.0.9:10085")
+	if got := c.Info().SecurityProtocol; got != "insecure" {
+		t.Fatalf("unset addr: security protocol %q, want insecure", got)
+	}
+}
+
+func TestSetNodeCredentials_ResolvesPerAddr(t *testing.T) {
+	tlsCreds := credentials.NewTLS(nil)
+	SetNodeCredentials(map[string]credentials.TransportCredentials{
+		"10.7.0.1:10085": tlsCreds,
+	})
+	t.Cleanup(func() { SetNodeCredentials(nil) })
+
+	if got := resolveCredentials("10.7.0.1:10085").Info().SecurityProtocol; got != "tls" {
+		t.Errorf("configured addr: security protocol %q, want tls", got)
+	}
+	if got := resolveCredentials("10.7.0.2:10085").Info().SecurityProtocol; got != "insecure" {
+		t.Errorf("other addr: security protocol %q, want insecure", got)
+	}
+}
+
+func TestBuildTLSCredentials_MissingCA(t *testing.T) {
+	if _, err := BuildTLSCredentials("/no/such/ca.pem", "/no/c.pem", "/no/c.key", ""); err == nil {
+		t.Fatal("expected error for missing ca_cert, got nil")
+	}
+}
+
+func TestBuildTLSCredentials_BadPEM(t *testing.T) {
+	dir := t.TempDir()
+	ca := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(ca, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildTLSCredentials(ca, "/no/c.pem", "/no/c.key", ""); err == nil {
+		t.Fatal("expected error for non-PEM ca_cert, got nil")
+	}
+}
+
+func TestBuildTLSCredentials_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	certPath := filepath.Join(dir, "client.pem")
+	keyPath := filepath.Join(dir, "client.key")
+	writeTestKeypair(t, caPath, certPath, keyPath)
+
+	creds, err := BuildTLSCredentials(caPath, certPath, keyPath, "eu-1.internal")
+	if err != nil {
+		t.Fatalf("BuildTLSCredentials: %v", err)
+	}
+	if got := creds.Info().SecurityProtocol; got != "tls" {
+		t.Errorf("security protocol %q, want tls", got)
+	}
+}
+
+// writeTestKeypair generates a self-signed cert usable as both a CA bundle and a
+// client keypair, writing PEM files for each path.
+func writeTestKeypair(t *testing.T, caPath, certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "raven-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		IsCA:         true,
+		DNSNames:     []string{"eu-1.internal"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	for path, data := range map[string][]byte{caPath: certPEM, certPath: certPEM, keyPath: keyPEM} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -16,6 +17,9 @@ import (
 	"github.com/alchemylink/raven-subscribe/internal/database"
 	"github.com/alchemylink/raven-subscribe/internal/models"
 	"github.com/alchemylink/raven-subscribe/internal/syncer"
+	"github.com/alchemylink/raven-subscribe/internal/xray"
+
+	"google.golang.org/grpc/credentials"
 )
 
 func main() {
@@ -31,6 +35,13 @@ func main() {
 	}
 	log.Printf("Server host: %s | Config dir: %s | Listen: %s",
 		cfg.ServerHost, cfg.ConfigDir, cfg.ListenAddr)
+
+	// ── Node transport security (multi-node mTLS, Phase 5) ────────────────────
+	// Build the per-node gRPC credentials before anything can dial a node. A
+	// node with a tls block dials over mTLS; every other api_addr stays
+	// plaintext. Fail closed: a configured-but-broken cert must never silently
+	// fall back to plaintext against a public HandlerService.
+	configureNodeCredentials(cfg)
 
 	// ── Database ────────────────────────────────────────────────────────────
 	db, err := database.New(cfg.DBPath)
@@ -153,6 +164,35 @@ func main() {
 		}
 	}
 	log.Println("Stopped")
+}
+
+// configureNodeCredentials builds mTLS transport credentials for every node
+// that declares a tls block and installs them on the xray dialer keyed by
+// api_addr. Nodes without a tls block (WireGuard/loopback) keep dialing
+// plaintext. A cert that fails to load is fatal — with a public api_addr the
+// only safe alternative to mTLS is refusing to start, never a plaintext dial.
+func configureNodeCredentials(cfg *config.Config) {
+	creds := make(map[string]credentials.TransportCredentials)
+	for _, n := range cfg.Nodes {
+		if n.TLS == nil {
+			continue
+		}
+		serverName := n.TLS.ServerName
+		if serverName == "" {
+			if host, _, err := net.SplitHostPort(n.APIAddr); err == nil {
+				serverName = host
+			} else {
+				serverName = n.APIAddr
+			}
+		}
+		c, err := xray.BuildTLSCredentials(n.TLS.CACert, n.TLS.ClientCert, n.TLS.ClientKey, serverName)
+		if err != nil {
+			log.Fatalf("Node %q mTLS: %v", n.Name, err)
+		}
+		creds[n.APIAddr] = c
+		log.Printf("Node %q: mTLS enabled (server_name=%s)", n.Name, serverName)
+	}
+	xray.SetNodeCredentials(creds)
 }
 
 // reconcileNodes syncs the resolved node topology from config into the DB and


### PR DESCRIPTION
Phase 5 of multi-node: **optional mutual-TLS** on the control plane's gRPC dial to a node's HandlerService, plus the design-doc flip and a repo-hygiene scrub.

## What
- **Per-node `tls` block** (`config.NodeTLS{ca_cert, client_cert, client_key, server_name?}`). raven-subscribe acts as the TLS client: presents the client cert/key, verifies the node against the CA, forces TLS 1.3. `server_name` defaults to the `api_addr` host.
- **Credentials resolve per `api_addr`** in the single dial chokepoint `dialXrayAPI` (`resolveCredentials`). A node with a `tls` block dials mTLS; every other address (WireGuard/loopback, single-node local) stays plaintext — so fanout/reconcile/restore/fallback/server call sites are untouched.
- **mTLS satisfies the public-grpc anti-footgun guard** — a `tls`-guarded node no longer needs `allow_public_grpc`. Guard now clears on any of: private/WG address, `tls` block, or explicit `allow_public_grpc`.
- **Fail-closed at startup** (`main.configureNodeCredentials`): a configured-but-broken cert is fatal, never a silent fallback to plaintext against a public address. Certs load once, not per-request.

## Commits
1. `feat` — the mTLS implementation + tests (config validation, creds builder/resolver, dial wiring).
2. `chore` — scrub a real relay domain that had slipped into a comment + hysteria tests (the sensitive-data hook only matches IPs from `hosts.yml`, not bare domains).
3. `docs` — flip `docs/multi-node-design.md` §7/§9/§10 from "mTLS planned" to shipped, add a public-address+mTLS node to the §4 example.

## Not in scope (remaining Phase 5)
- README + INSTALL multi-node operator section.
- Ansible role for homogeneous nodes (server-side cert + `clientAuth` on the Xray gRPC inbound).

## Verification
build, vet, `test -race`, staticcheck, gosec, golangci-lint (0 issues), mod-tidy — all green. No new dependencies. Single-node behaviour byte-identical (creds map empty → plaintext loopback as before).