### PR TITLE
docs: multi-node operator section in README and INSTALL (Phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supports **VLESS, VMess, Trojan, Shadowsocks, Hysteria2**, transports **XHTTP/Sp
 - [How it works](#how-it-works)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
+- [Multi-node](#multi-node)
 - [Subscription URLs](#subscription-urls)
 - [Admin API](#admin-api)
 - [Routing Rules](#routing-rules)
@@ -380,6 +381,138 @@ All other parameters use defaults.
 ```
 
 Use `127.0.0.1` when running behind nginx/caddy as reverse proxy.
+
+---
+
+## Multi-node
+
+One Raven control plane can drive **several Xray nodes** behind a single set of
+subscription URLs. Every user is provisioned onto the nodes they're placed on;
+their subscription carries one outbound per node, wrapped in the balancer, so
+the **client** picks the best node (least ping / least load) and fails over
+automatically when one goes down. This diversifies the entry IPs/ASNs a single
+token exposes — the property that matters most against DPI that blocks by
+destination IP.
+
+Nodes are **homogeneous**: they share the same inbound/REALITY shape and differ
+only in where clients connect (`public_host:public_port`) and where the control
+plane provisions them (`api_addr`). They must be provisioned ahead of time (the
+Ansible node role does this) so the api-inbound already exists.
+
+**Single-node is just the N=1 case** — omit `nodes` entirely and nothing below
+applies; behaviour is byte-identical to earlier releases.
+
+### Configure nodes
+
+Add an optional `nodes` array. When present, the legacy `xray_api_addr` /
+`api_user_inbound_tag` fields are no longer used for provisioning (`server_host`
+still serves as the balancer/host default).
+
+```jsonc
+{
+  "server_host": "vpn.example.com",
+  "admin_token": "your-secret-token",
+  "base_url": "https://vpn.example.com",
+
+  "nodes": [
+    {
+      "name": "eu-1",                    // stable node id (used as the DB key)
+      "api_addr": "10.7.0.1:10085",      // Xray gRPC HandlerService — a WireGuard/private address (see below)
+      "inbound_tag": "vless-reality-in", // inbound users are provisioned onto
+      "public_host": "eu1.example.com",  // goes into the client outbound for this node
+      "public_port": 443,
+      "enabled": true                    // in rotation; omit → true
+    },
+    {
+      "name": "eu-2", "api_addr": "10.7.0.2:10085",
+      "inbound_tag": "vless-reality-in",
+      "public_host": "eu2.example.com", "public_port": 443
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | Stable, unique node id. |
+| `api_addr` | yes | `host:port` of the node's Xray gRPC HandlerService. Must be a private/WG address unless guarded by `tls` or `allow_public_grpc`. |
+| `inbound_tag` | yes | Inbound tag users are added to on this node. |
+| `public_host` / `public_port` | yes | Where clients connect for this node (client outbound). |
+| `enabled` | no | `false` takes the node out of rotation (default `true`). |
+| `tls` | no | mTLS on the gRPC dial to this node — see below. |
+| `allow_public_grpc` | no | Escape-hatch acknowledging a public `api_addr` guarded out-of-band (e.g. a sidecar terminating mTLS). |
+
+### Transport security (gRPC to the node)
+
+The gRPC HandlerService is **full control** over the node's users and inbounds,
+so it must never be reachable in plaintext over the public internet. Raven
+refuses to start if a node's `api_addr` is public and unguarded. Two options:
+
+**1. WireGuard (recommended).** Bind Xray's gRPC to the node's WG address and
+list that address as `api_addr`. Encryption and mutual auth live at the WG
+layer; no certificates to manage. This is the default posture — a private
+`api_addr` needs no extra config.
+
+**2. mTLS.** For nodes without WG, add a per-node `tls` block. Raven becomes the
+TLS client: it presents its client certificate, verifies the node's server
+certificate against your CA, and forces TLS 1.3. mTLS also satisfies the
+public-address guard on its own (no `allow_public_grpc` needed).
+
+```jsonc
+{
+  "name": "eu-3",
+  "api_addr": "203.0.113.7:10085",       // public address is OK — guarded by tls below
+  "inbound_tag": "vless-reality-in",
+  "public_host": "eu3.example.com", "public_port": 443,
+  "tls": {
+    "ca_cert":     "/etc/raven/pki/node-ca.pem",     // CA that signed the node's server cert
+    "client_cert": "/etc/raven/pki/raven-client.pem",
+    "client_key":  "/etc/raven/pki/raven-client.key",
+    "server_name": "eu-3.internal"                   // optional; defaults to the api_addr host
+  }
+}
+```
+
+Certificates are read once at startup; a missing or unreadable cert is a **fatal
+error** (Raven never silently downgrades to plaintext). The node side must
+present a server certificate signed by `ca_cert` and require a client cert
+(`clientAuth`) on its gRPC inbound — the Ansible node role provisions this.
+
+### Placement (which users on which nodes)
+
+By default a new user is placed on **all enabled nodes**. To restrict a user to
+a subset, pass `nodes` when creating them, or manage placement afterwards:
+
+```bash
+# Create a user pinned to specific nodes (omit "nodes" → all enabled nodes)
+curl -H "X-Admin-Token: $TOKEN" -X POST https://vpn.example.com/api/users \
+  -d '{"username":"alice@vpn.example.com","nodes":["eu-1","eu-2"]}'
+
+# Inspect / replace / drop a user's placement
+curl -H "X-Admin-Token: $TOKEN"        https://vpn.example.com/api/users/alice@vpn.example.com/nodes
+curl -H "X-Admin-Token: $TOKEN" -X POST https://vpn.example.com/api/users/alice@vpn.example.com/nodes -d '{"nodes":["eu-1"]}'
+curl -H "X-Admin-Token: $TOKEN" -X DELETE https://vpn.example.com/api/users/alice@vpn.example.com/nodes/eu-2
+
+# List configured nodes (read-only; nodes are config-managed, not created via API)
+curl -H "X-Admin-Token: $TOKEN" https://vpn.example.com/api/nodes
+```
+
+### Health & recovery
+
+Xray's gRPC user additions are in-memory, so a node restart drops its API-added
+users. A reconcile loop re-applies each user's placement to every node once per
+sync interval, so nodes self-heal without operator action. Per-node health is
+exposed additively on the sync-status endpoint:
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" https://vpn.example.com/api/sync/status
+# → flat single-node fields, plus a "nodes" map:
+#   "nodes": { "eu-1": { "reachable": true, "users_target": 42, "users_present": 42, ... }, ... }
+```
+
+See [`docs/multi-node-design.md`](docs/multi-node-design.md) for the full design
+(topology, failure policy, security model) and [`docs/INSTALL.md`](docs/INSTALL.md#6-multi-node-deployment)
+for a step-by-step node bring-up.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -183,6 +183,86 @@ curl -H "X-Admin-Token: your-secret-token" http://localhost:8080/api/users
 
 ---
 
+## 6. Multi-node deployment
+
+Optional. Skip this section for a single-node install — the steps above already
+give you a complete N=1 deployment. Multi-node lets one control plane drive
+several Xray nodes behind the same subscription URLs; see the
+[Multi-node section of the README](../README.md#multi-node) for how it behaves
+and [`multi-node-design.md`](multi-node-design.md) for the full design.
+
+**Prerequisites for each extra node:**
+
+- Xray installed and running the **same** inbound/REALITY configuration as your
+  primary (nodes are homogeneous — same keys, same `inbound_tag`).
+- Xray's API enabled with `HandlerService` in `services`, listening on a
+  reachable `api_addr`.
+- The gRPC port protected — **do not expose plaintext gRPC on a public IP.**
+
+### 6.1 Reachability: WireGuard (recommended)
+
+Put every node's gRPC API on a WireGuard address and mesh the control plane with
+the nodes. Bind Xray's API inbound to the WG address (not `0.0.0.0`):
+
+```jsonc
+// on the node, in the Xray API inbound
+{ "listen": "10.7.0.2", "port": 10085, "protocol": "dokodemo-door",
+  "settings": { "address": "10.7.0.2" }, "tag": "api" }
+```
+
+Then reference that WG address as the node's `api_addr`. No certificates needed —
+WireGuard provides encryption and mutual authentication.
+
+### 6.2 Reachability: mTLS (nodes without WG)
+
+If a node has no WG path, expose its gRPC over TLS with client-certificate auth.
+On the **node**, front the HandlerService with a TLS listener that requires a
+client cert signed by your CA (e.g. via Xray's gRPC TLS `streamSettings`, or an
+stunnel/nginx-stream terminator). On the **control plane**, add a `tls` block to
+that node (see the README example). Provision a small PKI once:
+
+```bash
+# CA (keep the key offline / in vault)
+openssl genrsa -out node-ca.key 4096
+openssl req -x509 -new -nodes -key node-ca.key -sha256 -days 3650 \
+  -subj "/CN=raven-node-ca" -out node-ca.pem
+
+# Control-plane client cert (Raven presents this)
+openssl genrsa -out raven-client.key 2048
+openssl req -new -key raven-client.key -subj "/CN=raven-control-plane" -out raven-client.csr
+openssl x509 -req -in raven-client.csr -CA node-ca.pem -CAkey node-ca.key \
+  -CAcreateserial -days 825 -sha256 -out raven-client.pem
+```
+
+Ship `node-ca.pem`, `raven-client.pem`, `raven-client.key` to the control-plane
+host (e.g. under `/etc/raven/pki/`, mode `0600`, owned by the service user) and
+point the node's `tls` block at them. Raven reads them **once at startup** — a
+missing or unreadable cert is fatal, so it never falls back to plaintext.
+
+> The AlchemyLink Ansible node role automates node bring-up (homogeneous inbound,
+> API inbound, WG or the server-side mTLS listener). This section is the manual
+> equivalent for non-Ansible operators.
+
+### 6.3 Point the control plane at the nodes
+
+Add a `nodes` array to the control-plane `config.json` (see the README table for
+every field), then restart:
+
+```bash
+sudo systemctl restart xray-subscription
+
+# Existing users are backfilled onto all enabled nodes on first start.
+# Confirm each node is reachable and fully provisioned:
+curl -H "X-Admin-Token: your-secret-token" http://localhost:8080/api/sync/status
+# → look for "nodes": { "<name>": { "reachable": true, "users_present": N, ... } }
+```
+
+If a node shows `reachable: false` or `users_present` below `users_target`, the
+reconcile loop retries every sync interval — check the node's gRPC address,
+firewall/WG route, and (for mTLS) that the certs match.
+
+---
+
 ## Troubleshooting
 
 ### "No such file or directory" when starting

--- a/docs/INSTALL.ru.md
+++ b/docs/INSTALL.ru.md
@@ -182,6 +182,87 @@ curl -H "X-Admin-Token: ваш-секретный-токен" http://localhost:8
 
 ---
 
+## 6. Multi-node развёртывание
+
+Опционально. Для одиночной ноды пропустите — шаги выше уже дают полное
+развёртывание (случай N=1). Multi-node позволяет одному control plane управлять
+несколькими Xray-нодами за одними и теми же subscription-URL; поведение описано
+в [Multi-node секции README](../README.md#multi-node), полный дизайн — в
+[`multi-node-design.md`](multi-node-design.md).
+
+**Требования к каждой дополнительной ноде:**
+
+- Xray установлен и запущен с **той же** inbound/REALITY-конфигурацией, что и
+  основная (ноды гомогенны — одни ключи, один `inbound_tag`).
+- В Xray включён API с `HandlerService` в `services`, слушает на достижимом
+  `api_addr`.
+- gRPC-порт защищён — **не выставляйте plaintext gRPC на публичный IP.**
+
+### 6.1 Достижимость: WireGuard (рекомендуется)
+
+Разместите gRPC API каждой ноды на WireGuard-адресе и объедините control plane с
+нодами в mesh. Забиндите API-inbound Xray на WG-адрес (не `0.0.0.0`):
+
+```jsonc
+// на ноде, в API-inbound Xray
+{ "listen": "10.7.0.2", "port": 10085, "protocol": "dokodemo-door",
+  "settings": { "address": "10.7.0.2" }, "tag": "api" }
+```
+
+Затем укажите этот WG-адрес как `api_addr` ноды. Сертификаты не нужны —
+WireGuard обеспечивает шифрование и взаимную аутентификацию.
+
+### 6.2 Достижимость: mTLS (ноды без WG)
+
+Если у ноды нет WG-пути, выставьте её gRPC по TLS с client-cert аутентификацией.
+На **ноде** прикройте HandlerService TLS-листенером, требующим клиентский
+сертификат, подписанный вашим CA (через gRPC TLS `streamSettings` Xray, либо
+stunnel/nginx-stream терминатор). На **control plane** добавьте ноде `tls`-блок
+(пример — в README). Один раз развернуть небольшой PKI:
+
+```bash
+# CA (ключ держать оффлайн / в vault)
+openssl genrsa -out node-ca.key 4096
+openssl req -x509 -new -nodes -key node-ca.key -sha256 -days 3650 \
+  -subj "/CN=raven-node-ca" -out node-ca.pem
+
+# Клиентский сертификат control plane (его предъявляет Raven)
+openssl genrsa -out raven-client.key 2048
+openssl req -new -key raven-client.key -subj "/CN=raven-control-plane" -out raven-client.csr
+openssl x509 -req -in raven-client.csr -CA node-ca.pem -CAkey node-ca.key \
+  -CAcreateserial -days 825 -sha256 -out raven-client.pem
+```
+
+Скопируйте `node-ca.pem`, `raven-client.pem`, `raven-client.key` на хост control
+plane (например, в `/etc/raven/pki/`, режим `0600`, владелец — сервисный
+пользователь) и укажите их в `tls`-блоке ноды. Raven читает их **один раз на
+старте** — отсутствующий или нечитаемый сертификат фатален, отката на plaintext
+не будет.
+
+> Ansible-роль ноды AlchemyLink автоматизирует поднятие ноды (гомогенный inbound,
+> API-inbound, WG или серверный mTLS-листенер). Эта секция — ручной эквивалент
+> для тех, кто не использует Ansible.
+
+### 6.3 Указать control plane на ноды
+
+Добавьте массив `nodes` в `config.json` control plane (все поля — в таблице
+README) и перезапустите:
+
+```bash
+sudo systemctl restart xray-subscription
+
+# Существующие юзеры на первом старте раскладываются на все enabled-ноды.
+# Убедитесь, что каждая нода достижима и полностью заполнена:
+curl -H "X-Admin-Token: ваш-секретный-токен" http://localhost:8080/api/sync/status
+# → ищите "nodes": { "<name>": { "reachable": true, "users_present": N, ... } }
+```
+
+Если нода показывает `reachable: false` или `users_present` меньше
+`users_target`, reconcile-loop повторяет попытку каждый sync-интервал — проверьте
+gRPC-адрес ноды, firewall/WG-маршрут и (для mTLS) совпадение сертификатов.
+
+---
+
 ## Решение проблем
 
 ### "No such file or directory" при запуске


### PR DESCRIPTION
Documents the multi-node deployment surface shipped across Phases 1–5 (config, transport security, placement, health), now that #128 landed mTLS.

## Changes
- **README** — new `## Multi-node` section: `nodes` config with a field table, the WireGuard-default vs mTLS transport-security choice, placement API (per-user node subset), and per-node health via `/api/sync/status`.
- **docs/INSTALL.md** + **docs/INSTALL.ru.md** — new `6. Multi-node deployment`: node prerequisites, WireGuard reachability, an mTLS bring-up with an openssl PKI recipe, and pointing the control plane at the nodes. RU kept in sync with EN.

## Notes
- All API routes and `/api/sync/status` fields cross-checked against `internal/api` — nothing documented that isn't implemented.
- Placeholders only (`example.com`, RFC-5737 addresses). No code changes.

Remaining Phase 5 item: the Ansible node role in Raven-server-install (server-side homogeneous inbound + WG / mTLS listener).