### PR TITLE
docs: config↔API reference + fix dead design-doc link

### DIFF
--- a/docs/API_CONFIG_COMPATIBILITY.md
+++ b/docs/API_CONFIG_COMPATIBILITY.md
@@ -1,75 +1,59 @@
-# API ↔ Config Compatibility Report
+# Config ↔ API Reference
 
-## Summary
+Which `config.json` fields each API and subscription endpoint reads, and the
+edge cases worth knowing. For the full parameter list and defaults, see the
+[Configuration section of the README](../README.md#configuration).
 
-All API endpoints correctly use configuration fields. Defaults and fallbacks are applied where needed. One gap was fixed: enable/disable of a specific client (`PUT /api/users/{id}/clients/{inboundId}/enable|disable`) now syncs to Xray, matching the behavior of user-level enable/disable.
+## Config fields used by the API
 
----
-
-## Config Fields Used by API
-
-| Config Field | Used By | Default | Notes |
-|--------------|---------|---------|-------|
-| `admin_token` | All `/api/*` | `""` | Empty = no auth. Header `X-Admin-Token` or query `admin_token`. |
+| Config field | Used by | Default | Notes |
+|---|---|---|---|
+| `admin_token` | all `/api/*` | `""` | Empty = no auth. Send as header `X-Admin-Token` or query `admin_token`. |
 | `rate_limit_sub_per_min` | `/sub/*`, `/c/*` | `0` | 0 = disabled. |
 | `rate_limit_admin_per_min` | `/api/*` | `0` | 0 = disabled. |
-| `server_host` | Subscription, links | — | **Required** when config file is used. |
-| `base_url` | SubURL in responses | `http://localhost:8080` | Used for `sub_url` in user responses. |
-| `config_dir` | Add/remove users, sync | `/etc/xray/config.d` | Xray config files location. |
-| `socks_inbound_port` | Generated client config | `0` → 2080 | 0 = use default in generator. |
-| `http_inbound_port` | Generated client config | `0` → 1081 | 0 = use default in generator. |
-| `balancer_strategy` | Subscription config | `leastPing` | random, roundRobin, leastPing, leastLoad. |
-| `balancer_probe_url` | Subscription config | `https://www.gstatic.com/generate_204` | For leastPing/leastLoad. |
-| `balancer_probe_interval` | Subscription config | `30s` | JSON: `balancer_probe_interval`. |
-| `api_user_inbound_tag` | Create user, add client | `""` | When set, new users go to this inbound. |
-| `api_user_inbound_protocol` | Create user, add client | `""` | Fallback when tag not in config_dir. |
-| `api_user_inbound_port` | Create inbound fallback | `0` → 443 | Used when creating inbound from protocol. |
-| `xray_api_addr` | Add/remove users | `""` | Use Xray gRPC API instead of config files. |
-| `xray_config_file_mode` | Writes to `config_dir` JSON | `0600` | Octal string e.g. `0644` for group/other read (testing). |
+| `server_host` | subscription, links | — | **Required** when a config file is used. |
+| `base_url` | `sub_url` in responses | `http://localhost:8080` | Used for the `sub_url` field in user responses. |
+| `config_dir` | add/remove users, sync | `/etc/xray/config.d` | Xray config files location. |
+| `socks_inbound_port` | generated client config | `0` → 2080 | 0 = generator uses the default. |
+| `http_inbound_port` | generated client config | `0` → 1081 | 0 = generator uses the default. |
+| `balancer_strategy` | subscription config | `leastPing` | `random`, `roundRobin`, `leastPing`, `leastLoad`. |
+| `balancer_probe_url` | subscription config | `https://www.gstatic.com/generate_204` | For `leastPing`/`leastLoad`. |
+| `balancer_probe_interval` | subscription config | `30s` | |
+| `api_user_inbound_tag` | create user, add client | `""` | When set, new users go to this inbound. |
+| `api_user_inbound_protocol` | create user, add client | `""` | Fallback when the tag is not in `config_dir`. |
+| `api_user_inbound_port` | create inbound fallback | `0` → 443 | Used when creating an inbound from the protocol. |
+| `xray_api_addr` | add/remove users | `""` | Use the Xray gRPC API instead of config files. |
+| `xray_config_file_mode` | writes to `config_dir` JSON | `0600` | Octal string, e.g. `0644` for group/other read (testing). |
 
----
-
-## Endpoint ↔ Config Mapping
+## Endpoints and the config they read
 
 ### Subscription (public)
 
-| Endpoint | Config Used | Compatibility |
-|----------|-------------|---------------|
-| `/sub/{token}`, `/c/{token}` | ServerHost, SocksInboundPort, HTTPInboundPort, balancer* | OK — 0 ports fall back to 2080/1081 |
-| `/sub/{token}/links`, `/c/{token}/links.*` | BaseURL, ServerHost, SocksInboundPort, HTTPInboundPort | OK |
-| `/sub/{token}/vless|vmess|trojan|ss/*` | Same as above | OK |
+| Endpoint | Config read |
+|---|---|
+| `/sub/{token}`, `/c/{token}` | `server_host`, `socks_inbound_port`, `http_inbound_port`, `balancer_*` (0 ports fall back to 2080/1081) |
+| `/sub/{token}/links`, `/c/{token}/links.*` | `base_url`, `server_host`, `socks_inbound_port`, `http_inbound_port` |
+| `/sub/{token}/vless\|vmess\|trojan\|ss/*` | same as above |
 
-### Admin API
+### Admin API (`X-Admin-Token`)
 
-| Endpoint | Config Used | Compatibility |
-|----------|-------------|---------------|
-| `GET/POST /api/users` | AdminToken, BaseURL, APIUserInboundTag, APIUserInboundProtocol, ConfigDir, XrayAPIAddr | OK — `user` has no `email` field in JSON (Xray still uses username as client email internally). |
-| `GET/DELETE /api/users/{id}` | AdminToken, BaseURL, ConfigDir, XrayAPIAddr | OK — `{id}` must be numeric DB user id |
-| `PUT /api/users/{id}/enable|disable` | AdminToken, ConfigDir, XrayAPIAddr | OK |
-| `POST /api/users/{id}/token` | AdminToken, BaseURL | OK |
-| `GET/POST/PUT /api/users/{id}/routes` | AdminToken | OK |
-| `GET/POST /api/users/{id}/clients` | AdminToken, ConfigDir, XrayAPIAddr, APIUserInboundProtocol | OK |
-| `PUT /api/users/{id}/clients/{inboundId}/enable|disable` | AdminToken, ConfigDir, XrayAPIAddr | OK — **fixed**: now syncs to Xray |
-| `GET /api/inbounds` | — | OK |
-| `GET/PUT/POST/DELETE /api/routes/global` | AdminToken | OK |
-| `GET/PUT /api/config/balancer` | AdminToken, BalancerStrategy, BalancerProbeURL, BalancerProbeFreq | OK |
-| `POST /api/sync` | AdminToken, ConfigDir | OK |
+| Endpoint | Config read | Notes |
+|---|---|---|
+| `GET/POST /api/users` | `admin_token`, `base_url`, `api_user_inbound_tag`, `api_user_inbound_protocol`, `config_dir`, `xray_api_addr` | The JSON `user` has no `email` field (Xray uses the username as the client email internally). |
+| `GET/DELETE /api/users/{id}` | `admin_token`, `base_url`, `config_dir`, `xray_api_addr` | `{id}` is the numeric DB user id. |
+| `PUT /api/users/{id}/enable\|disable` | `admin_token`, `config_dir`, `xray_api_addr` | |
+| `POST /api/users/{id}/token` | `admin_token`, `base_url` | |
+| `GET/POST/PUT /api/users/{id}/routes` | `admin_token` | |
+| `GET/POST /api/users/{id}/clients` | `admin_token`, `config_dir`, `xray_api_addr`, `api_user_inbound_protocol` | |
+| `PUT /api/users/{id}/clients/{inboundId}/enable\|disable` | `admin_token`, `config_dir`, `xray_api_addr` | Syncs the per-client state to Xray. |
+| `GET /api/inbounds` | — | |
+| `GET/PUT/POST/DELETE /api/routes/global` | `admin_token` | |
+| `GET/PUT /api/config/balancer` | `admin_token`, `balancer_*` | |
+| `POST /api/sync` | `admin_token`, `config_dir` | |
 
----
+## Edge cases
 
-## Edge Cases
-
-1. **`config.Load("")`** — Returns defaults without validation. `server_host` can be empty. Use only for tests; production should use a config file path.
-
-2. **Empty `config_dir`** — Add/remove user will fail when using file-based sync. With `api_user_inbound_protocol` set, inbound can be created in DB; Xray config must exist elsewhere.
-
-3. **`xray_api_addr` without `api_user_inbound_tag`** — Restore on startup skips. Create user with explicit inbounds in body.
-
-4. **`socks_inbound_port` / `http_inbound_port` = 0** — Generator uses 2080 and 1081. No change needed.
-
----
-
-## Changes Made
-
-- **`setClientEnabled`** — Enable/disable of a specific client now syncs to Xray (config or API), consistent with user-level enable/disable.
-- **`GetUserClientByUserAndInbound`** — New DB method to fetch tag and client config for sync.
+1. **`config.Load("")`** — returns defaults without validation; `server_host` may be empty. For tests only — production must pass a config file path.
+2. **Empty `config_dir`** — file-based add/remove of users fails. With `api_user_inbound_protocol` set, the inbound can be created in the DB, but the Xray config must exist elsewhere.
+3. **`xray_api_addr` without `api_user_inbound_tag`** — restore-on-startup is skipped; create users with explicit inbounds in the request body.
+4. **`socks_inbound_port` / `http_inbound_port` = 0** — the generator uses 2080 and 1081. No action needed.

--- a/docs/multi-node-design.md
+++ b/docs/multi-node-design.md
@@ -11,7 +11,7 @@ Status: implemented, shipped in v0.4.0.
 Scope: Raven-subscribe. Touches `internal/{config,database,api,syncer,xray,core}`.
 It does **not** change the subscription output for single-node installs (see §10).
 Issue: [#100 multi node support](https://github.com/AlchemyLink/Raven-subscribe/issues/100).
-Related: [`internal-core-design.md`](internal-core-design.md) — multi-node builds on top of it.
+Related: multi-node builds on the `core.AdminAPI` write-path seam in `internal/core`.
 
 ## 1. Why
 

--- a/docs/multi-node-design.ru.md
+++ b/docs/multi-node-design.ru.md
@@ -11,7 +11,7 @@
 Область: Raven-subscribe. Затрагивает `internal/{config,database,api,syncer,xray,core}`.
 На вывод подписки для одноузловых установок это **не** влияет (см. §10).
 Issue: [#100 multi node support](https://github.com/AlchemyLink/Raven-subscribe/issues/100).
-Связано: [`internal-core-design.md`](internal-core-design.md) — multi-node надстраивается над ним.
+Связано: multi-node надстраивается над write-path `core.AdminAPI` в `internal/core`.
 
 ## 1. Зачем
 


### PR DESCRIPTION
Follow-up to the docs audience audit.

## Changes
- **`API_CONFIG_COMPATIBILITY.md`** was written as a one-time **audit report** ("Summary: one gap was fixed", a "Changes Made" section, per-row `OK`/`**fixed**`). Rewritten as a clean **Config ↔ API reference** for operators/integrators — which `config.json` fields each subscription/admin endpoint reads, plus edge cases — with a link to the README Configuration section for the full parameter list.
- **`multi-node-design.md` (+ `.ru.md`)** linked to `internal-core-design.md`, which is **not published** in the repo (dead link). Now points at the real `core.AdminAPI` seam in `internal/core`.

Audit outcome for the rest of `docs/`: INSTALL, the multi-node usage guide, and the multi-node design doc are correctly audienced (handled in #132). `SEO_CHECKLIST.md` left as-is by request. Docs-only.